### PR TITLE
upload

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -283,7 +283,7 @@ const created = await cozy.createFile(blob, {
     name: "filename",
     folderId: "123456",
 })
-const fileUpdated = await cozy.createFile(fileInput.files[0], { folderId: "" })
+const fileCreated = await cozy.createFile(fileInput.files[0], { folderId: "" })
 ```
 
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,5 @@
 [Cozy](https://cozy.io) Javascript Client
-==============================
+=========================================
 
 `cozy-client-js` is a javascript library made by Cozy. It enables client-side  applications to make requests to the cozy stack.
 
@@ -35,24 +35,8 @@ You can `import`/`require` cozy-client-js using npm & webpack
 You can also copy-paste the `dist/cozy-client.js` bundle file into your application, and include it in your application `index.html` with  `<script src="./cozy-client.js">`.
 
 
-
-Implemented API
------------------------
-
-# cozy.init(options)
-
-`cozy.init(options)` setup cozy-client-js and perform the necessary steps to retrieve the application token. Our goal is for you developer to not worry about how the token is retrieved, as it will depend on cozy version and context.
-
-Supported options are:
-
- - `target` : if the cozy you want to speak to is not on the same origin than the app. Useful for test, should not used for app installed inside Cozy.
-
-```javascript
-await cozy.init()
-// let's do something
-```
-
-# Doctypes & Permissions
+Doctypes & Permissions
+----------------------
 
 A doctype is a simple javascript string identifying a type of document.
 Some basic doctypes are provided by cozy, but you can pick your own.
@@ -79,7 +63,8 @@ When you use a doctype, even one created by your application, you need to ask fo
 **TODO** Have some docs about **v2** package.json vs **v3** manifest.webapp
 
 
-# Promises & callback
+Promises & Callbacks
+--------------------
 
 All cozy-client-js functions support callback or promise.
 
@@ -114,7 +99,23 @@ cozy.create(myBooksDoctype, doc, function(err, result){
 ```
 
 
-# cozy.create(doctype, attributes)
+Implemented API
+---------------
+
+### `cozy.init(options)`
+
+`cozy.init(options)` setup cozy-client-js and perform the necessary steps to retrieve the application token. Our goal is for you developer to not worry about how the token is retrieved, as it will depend on cozy version and context.
+
+Supported options are:
+
+ - `target` : if the cozy you want to speak to is not on the same origin than the app. Useful for test, should not used for app installed inside Cozy.
+
+```javascript
+await cozy.init()
+// let's do something
+```
+
+### `cozy.create(doctype, attributes)`
 
 `create(doctype, attributes)` adds a document to the database.
 
@@ -126,7 +127,6 @@ This function returns a promise for the created object. The created object has t
 
 On **v3**, an extra field `_rev` is added, it is the unique identifier for the document revision, after creation, it will be of the shape `1-xxxxxxxxx` for first revision.
 
-### Example :
 ```javascript
 // simple object
 var book = { title: "Moby Dick", author:"Herman Melville", isbn: "42" }
@@ -140,7 +140,7 @@ console.log(created._id, created._rev)
 createdBookId = created._id
 ```
 
-# cozy.find(doctype, id)
+### `cozy.find(doctype, id)`
 
 `cozy.find(doctype, id)` returns the document with the given ID.
 
@@ -153,7 +153,7 @@ doc = await cozy.find(myBooksDoctype, createdBookId)
 console.log(doc._id, doc._rev, doc.title, doc.author, doc.isbn)
 ```
 
-# cozy.update(doctype, doc, newdoc)
+### `cozy.update(doctype, doc, newdoc)`
 
 `cozy.update(doctype, doc, newdoc)` replaces the document by a new version.
 
@@ -173,7 +173,7 @@ console.log(updated.title, updated.year) // fields are changed
 console.log(updated.isbn === undefined) // update erase fields
 ```
 
-# cozy.updateAttributes(doctype, id, changes)
+### `cozy.updateAttributes(doctype, id, changes)`
 
 `cozy.updateAttributes(doctype, id, changes)` applies change to the document.
 
@@ -191,7 +191,7 @@ console.log(updated.year) // fields are changed
 console.log(updated.isbn) // updateAttributes preserve other fields
 ```
 
-# cozy.destroy(doctype, doc)
+### `cozy.destroy(doctype, doc)`
 
 `cozy.destroy(doctype, doc )` will erase the document from the database.
 
@@ -207,7 +207,7 @@ await cozy.destroy(myBooksDoctype, updated)
 ```
 
 
-# cozy.defineIndex(doctype, fields)
+### `cozy.defineIndex(doctype, fields)`
 
 `cozy.defineIndex(doctype, fields)` creates an index for a document type.
 
@@ -223,7 +223,7 @@ defineIndex is idempotent, it can be called several time with no bad effect
 booksByYearRef = await cozy.defineIndex(myType, 'year', 'rating')
 ```
 
-# cozy.query(indexReference, query)
+### `cozy.query(indexReference, query)`
 
 `cozy.query(indexReference, query)` find documents using an index.
 
@@ -250,6 +250,37 @@ resuts[0].title === "Moby Dick"
 resuts[0].rating < 2 // lowest rating first
 ```
 
+### `cozy.upload(data, options)`
+
+`upload(data, options)` is used to upload a new file onto your cozy, or update an already existing one.
+
+`data` can be of the following type: `Blob`, `File`, `ArrayBuffer`, `ArrayBufferView` or `string`.
+
+`options` is an object with the following fields:
+
+  - **mode**: specify the upload mode `create` or `update`. default: `create`
+  - **name**: in `create` mode, specify the name of the file. optional for a data of type `File`, type, mandatory otherwise.
+  - **folderId**: in `create` mode, specify identifier of the file's folder. if empty, it is the root folder.
+  - **fileId**: in `update` mode, specify the identifier of the file to modify.
+  - **contentType**: specify the content type of the uploaded data. For a `File` type, it is be handled automatically. default: `application/octet-stream`.
+
+**Warning** This API is not V2 compatible.
+
+```javascript
+const created = await cozy.upload(blob, {
+    mode: "create",
+    name: "filename",
+    folderId: "123456",
+})
+
+const updated = await cozy.upload(blob, {
+    mode: "update",
+    fileId: "654321",
+    contentType: "text/plain",
+})
+
+const fileUpdated = await cozy.upload(fileInput.files[0], { folderId: "" })
+```
 
 Future APIs
 -----------

--- a/docs/README.md
+++ b/docs/README.md
@@ -270,8 +270,7 @@ resuts[0].rating < 2 // lowest rating first
 
 `upload(data, options)` is used to upload a new file onto your cozy, or update an already existing one.
 
-`data` can be of the following type: `Blob`, `File`, `ArrayBuffer`, `ArrayBufferView` or `string`.
-
+- `data` can be of the following type: `Blob`, `File`, `ArrayBuffer`, `ArrayBufferView` or `string`.
 - `options` is an object with the following fields:
   * `mode`: specify the upload mode `create` or `update`. default: `create`
   * `name`: in `create` mode, specify the name of the file. optional for a data of type `File`, type, mandatory otherwise.

--- a/docs/README.md
+++ b/docs/README.md
@@ -266,34 +266,41 @@ resuts[0].rating < 2 // lowest rating first
 ```
 
 
-### `cozy.upload(data, options)`
+### `cozy.createFile(data, options)`
 
-`upload(data, options)` is used to upload a new file onto your cozy, or update an already existing one.
+`upload(data, options)` is used to upload a new file onto your cozy
 
 - `data` can be of the following type: `Blob`, `File`, `ArrayBuffer`, `ArrayBufferView` or `string`.
 - `options` is an object with the following fields:
-  * `mode`: specify the upload mode `create` or `update`. default: `create`
-  * `name`: in `create` mode, specify the name of the file. optional for a data of type `File`, type, mandatory otherwise.
-  * `folderId`: in `create` mode, specify identifier of the file's folder. if empty, it is the root folder.
-  * `fileId`: in `update` mode, specify the identifier of the file to modify.
+  * `name`: specify the name of the file. optional for a data of type `File`, type, mandatory otherwise.
+  * `folderId`: specify identifier of the file's folder. if empty, it is the root folder.
   * `contentType`: specify the content type of the uploaded data. For a `File` type, it is be handled automatically. default: `application/octet-stream`.
 
 **Warning** This API is not V2 compatible.
 
 ```javascript
-const created = await cozy.upload(blob, {
-    mode: "create",
+const created = await cozy.createFile(blob, {
     name: "filename",
     folderId: "123456",
 })
+const fileUpdated = await cozy.createFile(fileInput.files[0], { folderId: "" })
+```
 
-const updated = await cozy.upload(blob, {
-    mode: "update",
+
+### `cozy.updateFile(data, options)`
+
+`cozy.updateFile(data, options)` is used to update the content of an already existing file.
+
+- `data` can be of the following type: `Blob`, `File`, `ArrayBuffer`, `ArrayBufferView` or `string`.
+- `options` is an object with the following fields:
+  * `fileId`: specify the identifier of the file to modify.
+  * `contentType`: specify the content type of the uploaded data. For a `File` type, it is be handled automatically. default: `application/octet-stream`.
+
+```javascript
+const updated = await cozy.updateFile(blob, {
     fileId: "654321",
     contentType: "text/plain",
 })
-
-const fileUpdated = await cozy.upload(fileInput.files[0], { folderId: "" })
 ```
 
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -245,7 +245,7 @@ booksByYearRef = await cozy.defineIndex(myType, 'year', 'rating')
 
 - `query` is an object with the following fields:
   * `selector`: a mango selector
-  * ``limit`: maximum number of results
+  * `limit`: maximum number of results
   * `skip`: ignore the first x results (pagination)
 
 Results will be returned in order according to the index.

--- a/docs/planned.md
+++ b/docs/planned.md
@@ -22,15 +22,6 @@ children = await cozy.vfs.ls("path/to/dir")
 // vfs.stat(path) returns the metadata of a given directory of file
 metada = await cozy.vfs.stat("path/to/dir_or_file")
 
-// vfs.create(path, blob) creates a file at the given path
-// it throws if the path's dirname doesnt exists
-// it throws if the path exists
-await cozy.vfs.create("path/to/file.ext", Blob)
-
-// vfs.update(path, blob) update the content of a file at the given path
-// it throws if the path doesnt exists
-await cozy.vfs.update("path/to/file.ext", Blob)
-
 // vfs.getURL(path) returns an url for this path
 // the url can be used in an <image> or <audio> tag
 url = await cozy.vfs.getURL("path/to/file.ext")

--- a/src/files.js
+++ b/src/files.js
@@ -1,10 +1,15 @@
 /* global fetch Blob File */
-import { getParentDomain } from './utils'
+import {waitConfig} from './utils'
 
 const contentTypeOctetStream = 'application/octet-stream'
 
 // @data can be Blob | File | ArrayBuffer | ArrayBufferView | string
 export async function upload (data, args) {
+  const config = await waitConfig()
+  if (config.isV1) {
+    throw new Error('not implemented on V1')
+  }
+
   let { name, folderId } = args || {}
 
   if (!data) {
@@ -41,11 +46,10 @@ export async function upload (data, args) {
     throw new Error('missing name argument')
   }
 
-  const domain = getParentDomain()
   const query = `?Name=${encodeURIComponent(name)}&Type=io.cozy.files`
   const path = `/files/${encodeURIComponent(folderId)}`
 
-  return fetch(`${domain}${path}${query}`, options)
+  return fetch(`${config.target}${path}${query}`, options)
     .then((res) => {
       const json = res.json()
       if (!res.ok) {
@@ -57,5 +61,10 @@ export async function upload (data, args) {
 }
 
 export async function uploadFiles (files) {
+  const config = await waitConfig()
+  if (config.isV1) {
+    throw new Error('not implemented on V1')
+  }
+
   return Promise.all(Array.from(files).map(upload))
 }

--- a/src/files.js
+++ b/src/files.js
@@ -1,0 +1,61 @@
+/* global fetch Blob File */
+import { getParentDomain } from './utils'
+
+const contentTypeOctetStream = 'application/octet-stream'
+
+// @data can be Blob | File | ArrayBuffer | ArrayBufferView | string
+export async function upload (data, args) {
+  let { name, folderId } = args || {}
+
+  if (!data) {
+    throw new Error('missing data argument')
+  }
+
+  if (!folderId) folderId = ''
+
+  const headers = {}
+  const options = { method: 'POST', headers }
+
+  // transform any ArrayBufferView to ArrayBuffer
+  if (data.buffer && data.buffer instanceof ArrayBuffer) {
+    data = data.buffer
+  }
+
+  let contentType
+  if (typeof ArrayBuffer !== 'undefined' && data instanceof ArrayBuffer) {
+    contentType = contentTypeOctetStream
+  } else if (typeof File !== 'undefined' && data instanceof File) {
+    contentType = data.type || contentTypeOctetStream
+    if (!name) name = data.name
+  } else if (typeof Blob !== 'undefined' && data instanceof Blob) {
+    contentType = contentTypeOctetStream
+  } else if (typeof data === 'string') {
+    contentType = 'text/plain'
+  } else {
+    throw new Error('invalid data type')
+  }
+
+  headers['content-type'] = contentType
+
+  if (typeof name !== 'string' || name === '') {
+    throw new Error('missing name argument')
+  }
+
+  const domain = getParentDomain()
+  const query = `?Name=${encodeURIComponent(name)}&Type=io.cozy.files`
+  const path = `/files/${encodeURIComponent(folderId)}`
+
+  return fetch(`${domain}${path}${query}`, options)
+    .then((res) => {
+      const json = res.json()
+      if (!res.ok) {
+        return json.then(err => { throw err })
+      } else {
+        return json
+      }
+    })
+}
+
+export async function uploadFiles (files) {
+  return Promise.all(Array.from(files).map(upload))
+}

--- a/src/files.js
+++ b/src/files.js
@@ -7,7 +7,7 @@ const contentTypeOctetStream = 'application/octet-stream'
 export async function upload (data, args) {
   const config = await waitConfig()
   if (config.isV2) {
-    throw new Error('not implemented on V1')
+    throw new Error('not implemented on v2')
   }
 
   let { name, fileId, folderId, mode, contentType } = args || {}
@@ -90,13 +90,4 @@ export async function upload (data, args) {
         return json
       }
     })
-}
-
-export async function createFiles (files) {
-  const config = await waitConfig()
-  if (config.isV2) {
-    throw new Error('not implemented on V1')
-  }
-
-  return Promise.all(Array.from(files).map(upload))
 }

--- a/src/index.js
+++ b/src/index.js
@@ -39,9 +39,6 @@ let cozy = {
   },
   upload: function (data, args, optCallback) {
     return promiser(files.upload(data, args), optCallback)
-  },
-  uploadFiles: function (data, args, optCallback) {
-    return promiser(files.uploadFiles(data, args), optCallback)
   }
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 import * as crud from './crud'
 import * as mango from './mango'
+import * as files from './files'
 import init from './init'
 import {promiser, warn} from './utils'
 
@@ -35,6 +36,12 @@ let cozy = {
   destroy: function (doctype, doc, optCallback) {
     warn('destroy is deprecated, use cozy.delete instead.')
     return promiser(crud._delete(doctype, doc), optCallback)
+  },
+  upload: function (data, args, optCallback) {
+    return promiser(files.upload(data, args), optCallback)
+  },
+  uploadFiles: function (data, args, optCallback) {
+    return promiser(files.uploadFiles(data, args), optCallback)
   }
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -37,8 +37,11 @@ let cozy = {
     warn('destroy is deprecated, use cozy.delete instead.')
     return promiser(crud._delete(doctype, doc), optCallback)
   },
-  upload: function (data, args, optCallback) {
-    return promiser(files.upload(data, args), optCallback)
+  createFile: function (data, options, optCallback) {
+    return promiser(files.createFile(data, options), optCallback)
+  },
+  updateFile: function (data, options, optCallback) {
+    return promiser(files.updateFile(data, options), optCallback)
   }
 }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -98,13 +98,3 @@ export function warn (text) {
     console.log('Warning', text)
   }
 }
-
-export function getParentDomain () {
-  if (typeof document === 'undefined') {
-    return ''
-  }
-  const host = document.location.host
-  const subs = host.split('.')
-  subs.shift()
-  return `//${subs.join('.')}`
-}

--- a/src/utils.js
+++ b/src/utils.js
@@ -4,6 +4,7 @@ export let config = {}
 
 export function configure (opts) {
   config = opts
+  return config
 }
 
 export async function waitConfig (opts) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -98,3 +98,13 @@ export function warn (text) {
     console.log('Warning', text)
   }
 }
+
+export function getParentDomain () {
+  if (typeof document === 'undefined') {
+    return ''
+  }
+  const host = document.location.host
+  const subs = host.split('.')
+  subs.shift()
+  return `//${subs.join('.')}`
+}

--- a/test/integration/files.js
+++ b/test/integration/files.js
@@ -17,7 +17,7 @@ describe('files API', function () {
     })
   })
 
-  describe('Upload file', function () {
+  describe('Create file', function () {
     it('Works', async function () {
       if (config.isV2) {
         return
@@ -25,12 +25,25 @@ describe('files API', function () {
 
       const filename = 'foo_' + Math.random()
 
-      const created = await cozy.upload('datastring1', { name: filename })
+      const created = await cozy.createFile('datastring1', { name: filename })
+      created.data.should.have.property('attributes')
+    })
+  })
+
+  describe('Update file', function () {
+    it('Works', async function () {
+      if (config.isV2) {
+        return
+      }
+
+      const filename = 'foo_' + Math.random()
+
+      const created = await cozy.createFile('datastring1', { name: filename })
       created.data.should.have.property('attributes')
 
       const createdId = created.data.id
 
-      const updated = await cozy.upload('datastring2', { fileId: createdId, mode: 'update' })
+      const updated = await cozy.updateFile('datastring2', { fileId: createdId })
       updated.data.should.have.property('attributes')
     })
   })

--- a/test/integration/files.js
+++ b/test/integration/files.js
@@ -9,16 +9,29 @@ global.fetch = fetch
 const TARGET = process.env && process.env.TARGET || ''
 
 describe('files API', function () {
+  let config
+
   describe('Config', function () {
     it('When called against a real instance', async function () {
-      await cozy.init({ target: TARGET })
+      config = await cozy.init({ target: TARGET })
     })
   })
 
   describe('Upload file', function () {
     it('Works', async function () {
-      const uploaded = await cozy.upload('datastring', { name: 'foo' })
-      uploaded.data.should.have.property('attributes')
+      if (config.isV2) {
+        return
+      }
+
+      const filename = 'foo_' + Math.random()
+
+      const created = await cozy.upload('datastring1', { name: filename })
+      created.data.should.have.property('attributes')
+
+      const createdId = created.data.id
+
+      const updated = await cozy.upload('datastring2', { fileId: createdId, mode: 'update' })
+      updated.data.should.have.property('attributes')
     })
   })
 })

--- a/test/integration/files.js
+++ b/test/integration/files.js
@@ -1,0 +1,24 @@
+/* eslint-env mocha */
+
+// eslint-disable-next-line no-unused-vars
+import should from 'should'
+import cozy from '../../src'
+import fetch from 'isomorphic-fetch'
+global.fetch = fetch
+
+const TARGET = process.env && process.env.TARGET || ''
+
+describe('files API', function () {
+  describe('Config', function () {
+    it('When called against a real instance', async function () {
+      await cozy.init({ target: TARGET })
+    })
+  })
+
+  describe('Upload file', function () {
+    it('Works', async function () {
+      const uploaded = await cozy.upload('datastring', { name: 'foo' })
+      uploaded.data.should.have.property('attributes')
+    })
+  })
+})

--- a/test/mock-api.js
+++ b/test/mock-api.js
@@ -74,6 +74,33 @@ const ROUTES = [
         {'_id': '43', 'test': 'value'}
       ]
     }
+  },
+  {
+    name: 'UploadFile',
+    method: 'POST',
+    matcher: /^\/files\//,
+    response: {
+      data: {
+        type: 'io.cozy.files',
+        id: 'cb1c159a8db1ee7aeb9441c3ff001753',
+        attributes: {
+          type: 'file',
+          name: 'hospi.pdf',
+          folder_id: 'io.cozy.files.rootdir',
+          created_at: '2016-11-25T16:07:45.398867198+01:00',
+          updated_at: '2016-11-25T16:07:45.398867198+01:00',
+          size: '0',
+          md5sum: '1B2M2Y8AsgTpgAmY7PhCfg==',
+          mime: 'application/pdf',
+          class: 'application',
+          executable: false,
+          tags: []
+        },
+        meta: {},
+        links: {},
+        relationships: {}
+      }
+    }
   }
 ]
 

--- a/test/unit/files.js
+++ b/test/unit/files.js
@@ -20,9 +20,9 @@ describe('Files', function () {
     before(mock.mockAPI('UploadFile'))
 
     it('should work for supported data types', async function () {
-      const res1 = await cozy.upload('somestringdata', { name: 'foo', folderId: '12345', mode: 'create' })
-      const res2 = await cozy.upload(new Uint8Array(10), { name: 'foo', folderId: '12345', mode: 'create' })
-      const res3 = await cozy.upload(new ArrayBuffer(10), { name: 'foo', folderId: '12345', mode: 'create' })
+      const res1 = await cozy.createFile('somestringdata', { name: 'foo', folderId: '12345' })
+      const res2 = await cozy.createFile(new Uint8Array(10), { name: 'foo', folderId: '12345' })
+      const res3 = await cozy.createFile(new ArrayBuffer(10), { name: 'foo', folderId: '12345' })
 
       mock.calls('UploadFile').should.have.length(3)
       mock.lastUrl('UploadFile').should.equal('/files/12345?Name=foo&Type=io.cozy.files')
@@ -36,7 +36,7 @@ describe('Files', function () {
       let err = null
 
       try {
-        await cozy.upload(1)
+        await cozy.createFile(1, { name: 'name' })
       } catch (e) {
         err = e
       } finally {
@@ -46,7 +46,7 @@ describe('Files', function () {
       err = null
 
       try {
-        await cozy.upload({})
+        await cozy.createFile({}, { name: 'name' })
       } catch (e) {
         err = e
       } finally {
@@ -56,7 +56,7 @@ describe('Files', function () {
       err = null
 
       try {
-        await cozy.upload('')
+        await cozy.createFile('', { name: 'name' })
       } catch (e) {
         err = e
       } finally {
@@ -66,7 +66,7 @@ describe('Files', function () {
       err = null
 
       try {
-        await cozy.upload('somestringdata')
+        await cozy.createFile('somestringdata')
       } catch (e) {
         err = e
       } finally {
@@ -76,11 +76,41 @@ describe('Files', function () {
       err = null
 
       try {
-        await cozy.upload('somestringdata', { name: 'foo', mode: 'wat' })
+        await cozy.updateFile(1, { fileId: '12345' })
       } catch (e) {
         err = e
       } finally {
-        err.should.eql(new Error('unknown upload mode: "wat"'))
+        err.should.eql(new Error('invalid data type'))
+      }
+
+      err = null
+
+      try {
+        await cozy.updateFile({}, { fileId: '12345' })
+      } catch (e) {
+        err = e
+      } finally {
+        err.should.eql(new Error('invalid data type'))
+      }
+
+      err = null
+
+      try {
+        await cozy.updateFile('', { fileId: '12345' })
+      } catch (e) {
+        err = e
+      } finally {
+        err.should.eql(new Error('missing data argument'))
+      }
+
+      err = null
+
+      try {
+        await cozy.updateFile('somestringdata')
+      } catch (e) {
+        err = e
+      } finally {
+        err.should.eql(new Error('missing fileId argument'))
       }
 
       err = null

--- a/test/unit/files.js
+++ b/test/unit/files.js
@@ -8,13 +8,21 @@ import mock from '../mock-api'
 describe('Files', function () {
   afterEach(() => mock.restore())
 
+  describe('Init', function () {
+    before(mock.mockAPI('Status'))
+
+    it('Does nothing', async function () {
+      await cozy.init()
+    })
+  })
+
   describe('Upload', function () {
     before(mock.mockAPI('UploadFile'))
 
     it('should work for supported data types', async function () {
-      const res1 = await cozy.upload('somestringdata', { name: 'foo', folderId: '12345' })
-      const res2 = await cozy.upload(new Uint8Array(10), { name: 'foo', folderId: '12345' })
-      const res3 = await cozy.upload(new ArrayBuffer(10), { name: 'foo', folderId: '12345' })
+      const res1 = await cozy.upload('somestringdata', { name: 'foo', folderId: '12345', mode: 'create' })
+      const res2 = await cozy.upload(new Uint8Array(10), { name: 'foo', folderId: '12345', mode: 'create' })
+      const res3 = await cozy.upload(new ArrayBuffer(10), { name: 'foo', folderId: '12345', mode: 'create' })
 
       mock.calls('UploadFile').should.have.length(3)
       mock.lastUrl('UploadFile').should.equal('/files/12345?Name=foo&Type=io.cozy.files')
@@ -63,6 +71,16 @@ describe('Files', function () {
         err = e
       } finally {
         err.should.eql(new Error('missing name argument'))
+      }
+
+      err = null
+
+      try {
+        await cozy.upload('somestringdata', { name: 'foo', mode: 'wat' })
+      } catch (e) {
+        err = e
+      } finally {
+        err.should.eql(new Error('unknown upload mode: "wat"'))
       }
 
       err = null

--- a/test/unit/files.js
+++ b/test/unit/files.js
@@ -1,0 +1,71 @@
+/* eslint-env mocha */
+
+// eslint-disable-next-line no-unused-vars
+import should from 'should'
+import cozy from '../../src'
+import mock from '../mock-api'
+
+describe('Files', function () {
+  afterEach(() => mock.restore())
+
+  describe('Upload', function () {
+    before(mock.mockAPI('UploadFile'))
+
+    it('should work for supported data types', async function () {
+      const res1 = await cozy.upload('somestringdata', { name: 'foo', folderId: '12345' })
+      const res2 = await cozy.upload(new Uint8Array(10), { name: 'foo', folderId: '12345' })
+      const res3 = await cozy.upload(new ArrayBuffer(10), { name: 'foo', folderId: '12345' })
+
+      mock.calls('UploadFile').should.have.length(3)
+      mock.lastUrl('UploadFile').should.equal('/files/12345?Name=foo&Type=io.cozy.files')
+
+      res1.data.should.have.property('attributes')
+      res2.data.should.have.property('attributes')
+      res3.data.should.have.property('attributes')
+    })
+
+    it('should fail for unsupported data types', async function () {
+      let err = null
+
+      try {
+        await cozy.upload(1)
+      } catch (e) {
+        err = e
+      } finally {
+        err.should.eql(new Error('invalid data type'))
+      }
+
+      err = null
+
+      try {
+        await cozy.upload({})
+      } catch (e) {
+        err = e
+      } finally {
+        err.should.eql(new Error('invalid data type'))
+      }
+
+      err = null
+
+      try {
+        await cozy.upload('')
+      } catch (e) {
+        err = e
+      } finally {
+        err.should.eql(new Error('missing data argument'))
+      }
+
+      err = null
+
+      try {
+        await cozy.upload('somestringdata')
+      } catch (e) {
+        err = e
+      } finally {
+        err.should.eql(new Error('missing name argument'))
+      }
+
+      err = null
+    })
+  })
+})


### PR DESCRIPTION
This PR adds an `upload(data, options)` function. This upload function can be used in `create` or `update` mode. See the documentation for more details on the way this function works.

-----

NOTE: I tried to unify a little bit better the documentation and tried to follow this template:

```
### cozy.function(arg1, arg2)

`cozy.function(arg1, arg2)` is used to ....

It returns ...

If it ... (error cases)

**Warning** (if any)

- arg1 is a string specifying ...
- arg2 is an object with the following fields
  * field1 ...
  * field2 ...

example...
```