### PR TITLE
Fix options passing on constructor

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -64,7 +64,9 @@ class Cozy {
       MemoryStorage: MemoryStorage
     }
     this._inited = false
-    this.init(options)
+    if (options) {
+      this.init(options)
+    }
   }
 
   init (options = {}) {


### PR DESCRIPTION
To not run init if no options are passed to the constructor.
This fixes the init of the global instance `window.cozy` on browsers.