### PR TITLE
call init to re-init

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -106,10 +106,6 @@ class Cozy {
   }
 
   init (options = {}) {
-    if (this._inited) {
-      throw new Error('Already inited instance')
-    }
-
     this._inited = true
     this._oauth = false // is oauth activated or not
     this._token = null  // application token


### PR DESCRIPTION
I believe there is no reason to prevent initialization if `cozy-client` has already been initialized.

For example, if a user errs in the cozy server's url, `cozy-client` attemps to initialize, receives HTTP errors that are displayed to the user who has the opportunity to change the url. Then `cozy-client` must be reset/re-initialized.