### PR TITLE
Add 2 steps download

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -394,7 +394,7 @@ const trashed = await cozy.files.trash("1234567")
 
 ### `cozy.files.downloadById(id)`
 
-`cozy.files.downloadById(id)` is used to download a file identified by the given id.
+`cozy.files.downloadById(id)` is used to download a file identified by the given id. The file is downloaded through the browser fetch method, use this if you plan to use the file in javascript after.
 
 It returns a promise of a fetch `Response` object. This response object can be used to extract the information in the wanted form.
 
@@ -410,7 +410,7 @@ const buff = await response.arrayBuffer()
 
 ### `cozy.files.downloadByPath(path)`
 
-`cozy.files.downloadByPath(path)` is used to download a file identified by the given path.
+`cozy.files.downloadByPath(path)` is used to download a file identified by the given path. The file is downloaded through the browser fetch method, use this if you plan to use the file in javascript after.
 
 It returns a promise of a fetch `Response` object. This response object can be used to extract the information in the wanted form.
 
@@ -423,6 +423,41 @@ const text = await response.text()
 const buff = await response.arrayBuffer()
 ```
 
+### `cozy.files.getDowloadLink(path)`
+
+`cozy.files.getDowloadLink(path)` is used to get a download link for the file  identified by the given path.
+
+It returns a promise for the download link.
+Download link are only valid for a short while (default 1 hour)
+You can use this link to start a browser download like this:
+
+```javascript
+const href = await cozy.files.getDowloadLink("/foo/hello.txt")
+const link = document.createElement('a')
+link.href = href
+link.download = fileName
+document.body.appendChild(link) && link.click()
+```
+
+- `path` is a string specying the path of the file
+
+
+### `cozy.files.getArchiveLink(paths)`
+
+`cozy.files.getArchiveLink(paths)` is used to get a download link for a zip file containing all the files identified by the given paths.
+
+It returns a promise for the download link.
+Download link are only valid for a short while (default 1 hour)
+You can use this link to start a browser download (see code in getDowloadLink)
+
+```javascript
+const href = await cozy.files.getArchiveLink("/foo/hello.txt")
+```
+
+- `path` is a string specying the path of the file
+
+
+- `ids` is an array of file ids.
 
 ## Settings
 

--- a/src/files.js
+++ b/src/files.js
@@ -152,6 +152,29 @@ export function downloadByPath (cozy, path) {
   return cozyFetch(cozy, `/files/download?Path=${encodeURIComponent(path)}`)
 }
 
+function extractResponseLinkRelated (res) {
+  let href = res.links && res.links.related
+  if (!href) throw new Error('No related link in server response')
+  return href
+}
+
+export function getDowloadLink (cozy, path) {
+  return cozyFetchJSON(cozy, 'POST', `/files/downloads?Path=${encodeURIComponent(path)}`)
+    .then(extractResponseLinkRelated)
+}
+
+export function getArchiveLink (cozy, paths, name = 'files') {
+  const archive = {
+    type: 'io.cozy.archives',
+    attributes: {
+      name: name,
+      files: paths
+    }
+  }
+  return cozyFetchJSON(cozy, 'POST', `/files/archive`, {data: archive})
+  .then(extractResponseLinkRelated)
+}
+
 export function listTrash (cozy) {
   return cozyFetchJSON(cozy, 'GET', `/files/trash`)
 }

--- a/src/index.js
+++ b/src/index.js
@@ -59,6 +59,8 @@ const filesProto = {
   statByPath: files.statByPath,
   downloadById: files.downloadById,
   downloadByPath: files.downloadByPath,
+  getDowloadLink: files.getDowloadLink,
+  getArchiveLink: files.getArchiveLink,
   listTrash: files.listTrash,
   clearTrash: files.clearTrash,
   restoreById: files.restoreById,

--- a/src/jsonapi.js
+++ b/src/jsonapi.js
@@ -6,11 +6,12 @@ function findByRef (resources, ref) {
   return resources[indexKey(ref)]
 }
 
-function handleResource (rawResource, resources) {
+function handleResource (rawResource, resources, links) {
   let resource = {
     _id: rawResource.id,
     _type: rawResource.type,
     _rev: rawResource.meta.rev,
+    links: Object.assign({}, rawResource.links, links),
     attributes: rawResource.attributes,
     relations: (name) => {
       let rels = rawResource.relationships[name]
@@ -31,13 +32,13 @@ function handleTopLevel (doc, resources = {}) {
   const included = doc.included
 
   if (Array.isArray(included)) {
-    included.forEach((r) => handleResource(r, resources))
+    included.forEach((r) => handleResource(r, resources, doc.links))
   }
 
   if (Array.isArray(doc.data)) {
-    return doc.data.map((r) => handleResource(r, resources))
+    return doc.data.map((r) => handleResource(r, resources, doc.links))
   } else {
-    return handleResource(doc.data, resources)
+    return handleResource(doc.data, resources, doc.links)
   }
 }
 

--- a/test/unit/jsonapi.js
+++ b/test/unit/jsonapi.js
@@ -7,15 +7,15 @@ import jsonapiUnpack from '../../src/jsonapi'
 describe('unpacking', function () {
   it('simple data', function () {
     let result = jsonapiUnpack({
+      'links': {
+        'self': '/io.cozy.testobject/42'
+      },
       'data': {
         'attributes': {
           'test': 'value'
         },
         'type': 'io.cozy.testobject',
         'id': '42',
-        'links': {
-          'self': '/io.cozy.testobject/42'
-        },
         'meta': {
           'rev': '1-24'
         }


### PR DESCRIPTION
Add a function to generate a download link for 1 or more files.

We keep the old download in parallel as it might be useful for other use-cases.