### PR TITLE
Fix file creation date

### DIFF
--- a/src/files.js
+++ b/src/files.js
@@ -48,7 +48,7 @@ function doUpload (cozy, data, method, path, options) {
     method: method,
     headers: {
       'Content-Type': contentType,
-      'Date': lastModifiedDate ? lastModifiedDate.toISOString() : ''
+      'Date': lastModifiedDate ? lastModifiedDate.toGMTString() : ''
     },
     body: data
   })

--- a/test/integration/files.js
+++ b/test/integration/files.js
@@ -28,14 +28,18 @@ describe('files API', async function () {
 
   it('creates a file', async function () {
     const filename = 'foo_' + random()
+    const date = new Date('Wed, 01 Feb 2017 10:24:42 GMT')
 
     const created = await cozy.files.create('datastring1', {
       name: filename,
-      contentType: 'application/json'
+      contentType: 'application/json',
+      lastModifiedDate: date
     })
 
     created.should.have.property('attributes')
     created.attributes.md5sum.should.equal('7Zfd8PaeeXsm5WJesf/KJw==')
+    new Date(created.attributes.created_at).should.eql(date)
+    new Date(created.attributes.updated_at).should.eql(date)
   })
 
   it('updates a file', async function () {

--- a/test/unit/files.js
+++ b/test/unit/files.js
@@ -20,7 +20,7 @@ describe('Files', function () {
     before(mock.mockAPI('UploadFile'))
 
     it('should work for supported data types', async function () {
-      const date = new Date('2017-02-01T10:24:42.116Z')
+      const date = new Date('Wed, 01 Feb 2017 10:24:42 GMT')
       const res1 = await cozy.files.create('somestringdata', { name: 'foo', dirID: '12345', contentType: 'text/html' })
       const res2 = await cozy.files.create(new Uint8Array(10), { name: 'foo', dirID: '12345', lastModifiedDate: date })
       const res3 = await cozy.files.create(new ArrayBuffer(10), { name: 'foo', dirID: '12345' })
@@ -28,7 +28,7 @@ describe('Files', function () {
       const calls = mock.calls('UploadFile')
       calls.should.have.length(3)
       calls[0][1].headers['Content-Type'].should.equal('text/html')
-      calls[1][1].headers['Date'].should.equal(date.toISOString())
+      calls[1][1].headers['Date'].should.equal(date.toGMTString())
       mock.lastUrl('UploadFile').should.equal('http://my.cozy.io/files/12345?Name=foo&Type=file')
 
       res1.should.have.property('attributes')


### PR DESCRIPTION
Use GMT format since javascript's toISOString doesn't play
well with golang.