### PR TITLE
Make node stream support official in cozy.files.downloadBy*()

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -452,6 +452,7 @@ const response = await cozy.files.downloadById("1234567")
 const blob = await response.blob()
 const text = await response.text()
 const buff = await response.arrayBuffer()
+response.pipe(fs.createWriteStream('/some/file'))
 ```
 
 
@@ -468,6 +469,7 @@ const response = await cozy.files.downloadByPath("/foo/hello.txt")
 const blob = await response.blob()
 const text = await response.text()
 const buff = await response.arrayBuffer()
+response.pipe(fs.createWriteStream('/some/file'))
 ```
 
 ### `cozy.files.getDowloadLink(path)`

--- a/test/unit/files.js
+++ b/test/unit/files.js
@@ -310,6 +310,7 @@ describe('Files', function () {
 
         mock.calls('DownloadByID').should.have.length(1)
         mock.lastUrl('DownloadByID').should.equal('http://my.cozy.io/files/download/id42')
+        res.body.should.be.instanceOf(Readable)
 
         const txt = await res.text()
         txt.should.equal('foo')
@@ -324,6 +325,7 @@ describe('Files', function () {
 
         mock.calls('DownloadByPath').should.have.length(1)
         mock.lastUrl('DownloadByPath').should.equal('http://my.cozy.io/files/download?Path=%2Fbills%2Fh%C3%B4pital.pdf')
+        res.body.should.be.instanceOf(Readable)
 
         const txt = await res.text()
         txt.should.equal('foo')


### PR DESCRIPTION
It already works thanks to node-fetch.

Add some assertions in unit test to make sure body remains
the same upstream, and update documentation accordingly.