### PR TITLE
fix: getClient needs only clientID and registrationAccessToken

### DIFF
--- a/src/auth_v3.js
+++ b/src/auth_v3.js
@@ -28,14 +28,16 @@ export class Client {
     this.logoURI = opts.logoURI || opts.logo_uri || ''
     this.policyURI = opts.policyURI || opts.policy_uri || ''
 
-    if (this.redirectURI === '') {
-      throw new Error('Missing redirectURI field')
-    }
-    if (this.softwareID === '') {
-      throw new Error('Missing softwareID field')
-    }
-    if (this.clientName === '') {
-      throw new Error('Missing clientName field')
+    if (!this.registrationAccessToken) {
+      if (this.redirectURI === '') {
+        throw new Error('Missing redirectURI field')
+      }
+      if (this.softwareID === '') {
+        throw new Error('Missing softwareID field')
+      }
+      if (this.clientName === '') {
+        throw new Error('Missing clientName field')
+      }
     }
   }
 

--- a/test/unit/auth.js
+++ b/test/unit/auth.js
@@ -102,14 +102,9 @@ describe('Authentication', function () {
         token: 'apptoken'
       })
 
-      const client = await cozy.auth.getClient({
-        clientID: '123',
-        clientSecret: 'blabla',
-        redirectURI: 'http://coucou/',
-        softwareID: 'id',
-        clientName: 'client',
-        registrationAccessToken: '789'
-      })
+      const clientID = '123'
+      const registrationAccessToken = '789'
+      const client = await cozy.auth.getClient({ clientID, registrationAccessToken })
 
       client.clientID.should.equal('123')
       client.clientSecret.should.equal('456')


### PR DESCRIPTION
I don't know why there were an exception thrown if we create a client without `redirectURI`, `softwareID` or `clientName`.
It does not really help when we want to `getClient()`.

But it may be mandatory for `cozy.init()` with oauth, does not it?