### PR TITLE
Build UMD modules in root['cozy']

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 /* global fetch */
+
 import {unpromiser, retry, warn} from './utils'
 import {LocalStorage, MemoryStorage} from './auth_storage'
 import {AppToken as AppTokenV2, getAppToken as getAppTokenV2} from './auth_v2'
@@ -91,7 +92,7 @@ const settingsProto = {
   diskUsage: settings.diskUsage
 }
 
-class Cozy {
+class Client {
   constructor (options) {
     this.files = {}
     this.offline = {}
@@ -244,12 +245,6 @@ function addToProto (ctx, obj, proto, disablePromises) {
   }
 }
 
-const cozy = new Cozy()
-
-export default cozy
-export { Cozy, LocalStorage, MemoryStorage }
-
-if ((typeof window) !== 'undefined') {
-  window.cozy = cozy
-  window.Cozy = Cozy
-}
+module.exports = new Client()
+module.exports.LocalStorage = LocalStorage
+module.exports.MemoryStorage = MemoryStorage

--- a/src/index.js
+++ b/src/index.js
@@ -246,5 +246,4 @@ function addToProto (ctx, obj, proto, disablePromises) {
 }
 
 module.exports = new Client()
-module.exports.LocalStorage = LocalStorage
-module.exports.MemoryStorage = MemoryStorage
+Object.assign(module.exports, {Client, LocalStorage, MemoryStorage})

--- a/test/integration/crud.js
+++ b/test/integration/crud.js
@@ -3,7 +3,7 @@
 // eslint-disable-next-line no-unused-vars
 import should from 'should'
 import 'isomorphic-fetch'
-import {Cozy} from '../../src'
+import {Client} from '../../src'
 import mockTokenRetrieve from '../mock-iframe-token'
 
 const COZY_STACK_URL = process.env && process.env.COZY_STACK_URL || ''
@@ -13,14 +13,14 @@ const COZY_STACK_TOKEN = process.env && process.env.COZY_STACK_TOKEN
 describe('crud API', function () {
   let docID = null
   let docRev = null
-  let cozy
+  const cozy = {}
 
   if (COZY_STACK_VERSION === '2') {
     before(mockTokenRetrieve)
   }
 
   beforeEach(() => {
-    cozy = new Cozy({
+    cozy.client = new Client({
       cozyURL: COZY_STACK_URL,
       token: COZY_STACK_TOKEN
     })
@@ -31,7 +31,7 @@ describe('crud API', function () {
       const testDoc = {
         'test': 'value'
       }
-      const created = await cozy.create('io.cozy.testobject', testDoc)
+      const created = await cozy.client.create('io.cozy.testobject', testDoc)
       created.should.have.property('_id')
       created.should.have.property('_rev')
       created.should.have.property('test', 'value')
@@ -42,7 +42,7 @@ describe('crud API', function () {
 
   describe('Fetch document', function () {
     it('Works', async function () {
-      let fetched = await cozy.find('io.cozy.testobject', docID)
+      let fetched = await cozy.client.find('io.cozy.testobject', docID)
       fetched.should.have.property('_id', docID)
       fetched.should.have.property('_rev', docRev)
       fetched.should.have.property('test', 'value')
@@ -54,7 +54,7 @@ describe('crud API', function () {
       const changes = {
         'test': 'value2'
       }
-      const updated = await cozy.update('io.cozy.testobject', { _id: docID, _rev: docRev }, changes)
+      const updated = await cozy.client.update('io.cozy.testobject', { _id: docID, _rev: docRev }, changes)
       updated.should.have.property('_id', docID)
       updated.should.have.property('_rev')
       updated.should.have.property('test', 'value2')
@@ -65,7 +65,7 @@ describe('crud API', function () {
 
   describe('Delete document', function () {
     it('Works', async function () {
-      const deleted = await cozy.delete('io.cozy.testobject', { _id: docID, _rev: docRev })
+      const deleted = await cozy.client.delete('io.cozy.testobject', { _id: docID, _rev: docRev })
       deleted.should.have.property('id', docID)
       deleted.should.have.property('rev')
     })

--- a/test/integration/mango.js
+++ b/test/integration/mango.js
@@ -3,7 +3,7 @@
 // eslint-disable-next-line no-unused-vars
 import should from 'should'
 import 'isomorphic-fetch'
-import {Cozy} from '../../src'
+import {Client} from '../../src'
 import mockTokenRetrieve from '../mock-iframe-token'
 
 const COZY_STACK_URL = process.env && process.env.COZY_STACK_URL || ''
@@ -22,14 +22,14 @@ let docs = [
 describe('mango API', function () {
   let indexOnGroup = null
   let indexOnGroupAndYear = null
-  let cozy
+  const cozy = {}
 
   if (COZY_STACK_VERSION === '2') {
     before(mockTokenRetrieve)
   }
 
   before(function () {
-    cozy = new Cozy({
+    cozy.client = new Client({
       cozyURL: COZY_STACK_URL,
       token: COZY_STACK_TOKEN
     })
@@ -37,31 +37,31 @@ describe('mango API', function () {
 
   before(async function () {
     for (var i = 0, l = docs.length; i < l; i++) {
-      docs[i] = await cozy.create(DOCTYPE, docs[i])
+      docs[i] = await cozy.client.create(DOCTYPE, docs[i])
     }
   })
 
   after(async function () {
     for (var i = 0, l = docs.length; i < l; i++) {
-      await cozy.delete(DOCTYPE, docs[i])
+      await cozy.client.delete(DOCTYPE, docs[i])
     }
   })
 
   it('Define indexOnGroup', async function () {
-    indexOnGroup = await cozy.defineIndex(DOCTYPE, ['group'])
+    indexOnGroup = await cozy.client.defineIndex(DOCTYPE, ['group'])
   })
 
   it('Redefine the same index', async function () {
-    await cozy.defineIndex(DOCTYPE, ['group'])
+    await cozy.client.defineIndex(DOCTYPE, ['group'])
     // should.not.throw
   })
 
   it('Define indexOnGroupAndYear', async function () {
-    indexOnGroupAndYear = await cozy.defineIndex(DOCTYPE, ['group', 'year'])
+    indexOnGroupAndYear = await cozy.client.defineIndex(DOCTYPE, ['group', 'year'])
   })
 
   it('Query indexOnGroup', async function () {
-    let results = await cozy.query(indexOnGroup, {
+    let results = await cozy.client.query(indexOnGroup, {
       selector: {group: 'A'}
     })
 
@@ -70,7 +70,7 @@ describe('mango API', function () {
   })
 
   it('Query indexOnGroupAndYear', async function () {
-    let results = await cozy.query(indexOnGroupAndYear, {
+    let results = await cozy.client.query(indexOnGroupAndYear, {
       selector: {group: 'A'}
     })
 
@@ -79,7 +79,7 @@ describe('mango API', function () {
   })
 
   it('Query indexOnGroupAndYear with 2 fields', async function () {
-    let results = await cozy.query(indexOnGroupAndYear, {
+    let results = await cozy.client.query(indexOnGroupAndYear, {
       selector: {group: 'A', year: {$gte: 1900, $lt: 2200}}
     })
 
@@ -88,11 +88,11 @@ describe('mango API', function () {
   })
 
   it('Query indexOnGroupAndYear with 2 fields and sorted', async function () {
-    let sortedResults = await cozy.query(indexOnGroupAndYear, {
+    let sortedResults = await cozy.client.query(indexOnGroupAndYear, {
       selector: {group: 'A', year: {$gte: 1900, $lt: 2200}},
       descending: true
     })
-    let nonSortedresults = await cozy.query(indexOnGroupAndYear, {
+    let nonSortedresults = await cozy.client.query(indexOnGroupAndYear, {
       selector: {group: 'A', year: {$gte: 1900, $lt: 2200}}
     })
 

--- a/test/integration/offline.js
+++ b/test/integration/offline.js
@@ -3,7 +3,7 @@
 // eslint-disable-next-line no-unused-vars
 import should from 'should'
 import 'isomorphic-fetch'
-import {Cozy} from '../../src'
+import {Client} from '../../src'
 import PouchDB from 'pouchdb'
 PouchDB.plugin(require('pouchdb-adapter-memory'))
 
@@ -21,35 +21,35 @@ let docs = [
 ]
 
 describe('offline', function () {
-  let cozy
+  const cozy = {}
 
   before(async function () {
     if (COZY_STACK_VERSION === '2') {
       return this.skip()
     }
-    cozy = new Cozy({
+    cozy.client = new Client({
       cozyURL: COZY_STACK_URL,
       token: COZY_STACK_TOKEN
     })
     for (var i = 0, l = docs.length; i < l; i++) {
-      docs[i] = await cozy.create(DOCTYPE, docs[i])
+      docs[i] = await cozy.client.create(DOCTYPE, docs[i])
     }
   })
 
   after(async function () {
     if (COZY_STACK_VERSION === '3') {
       for (var i = 0, l = docs.length; i < l; i++) {
-        await cozy.delete(DOCTYPE, docs[i])
+        await cozy.client.delete(DOCTYPE, docs[i])
       }
-      cozy.offline.stopAllSync()
+      cozy.client.offline.stopAllSync()
     }
   })
 
   it('can replicate database from cozy', async function () {
-    cozy.offline.createDatabase(DOCTYPE, {adapter: 'memory'})
-    let complete = await cozy.offline.replicateFromCozy(DOCTYPE)
+    cozy.client.offline.createDatabase(DOCTYPE, {adapter: 'memory'})
+    let complete = await cozy.client.offline.replicateFromCozy(DOCTYPE)
     complete.docs_written.should.not.equal(0)
-    complete = await cozy.offline.replicateFromCozy(DOCTYPE)
+    complete = await cozy.client.offline.replicateFromCozy(DOCTYPE)
     complete.docs_written.should.equal(0)
   }).timeout(3 * 1000)
 
@@ -57,8 +57,8 @@ describe('offline', function () {
     let err = null
 
     try {
-      cozy.offline.createDatabase(DOCTYPE, {adapter: 'memory'})
-      await cozy.offline.replicateFromCozy(DOCTYPE, {live: true})
+      cozy.client.offline.createDatabase(DOCTYPE, {adapter: 'memory'})
+      await cozy.client.offline.replicateFromCozy(DOCTYPE, {live: true})
     } catch (e) {
       err = e
     } finally {
@@ -67,9 +67,9 @@ describe('offline', function () {
   })
 
   it('can auto replicate database', async function () {
-    let db = cozy.offline.createDatabase(DOCTYPE, {adapter: 'memory'})
+    let db = cozy.client.offline.createDatabase(DOCTYPE, {adapter: 'memory'})
     const lastSeq = await new Promise((resolve) => {
-      cozy.offline.replicateFromCozy(DOCTYPE, {}, {complete: (info) => {
+      cozy.client.offline.replicateFromCozy(DOCTYPE, {}, {complete: (info) => {
         db.changes().on('complete', (info) => {
           resolve(info.last_seq)
         })
@@ -81,9 +81,9 @@ describe('offline', function () {
       .on('change', (change) => { count++ })
 
     const smallDoc = {test: 187}
-    cozy.offline.startSync(DOCTYPE, 3)
+    cozy.client.offline.startSync(DOCTYPE, 3)
     await new Promise(resolve => setTimeout(resolve, 1 * 1000))
-    let doc = await cozy.create(DOCTYPE, smallDoc)
+    let doc = await cozy.client.create(DOCTYPE, smallDoc)
     const docId = doc._id
 
     let err = null

--- a/test/integration/relations.js
+++ b/test/integration/relations.js
@@ -3,7 +3,7 @@
 // eslint-disable-next-line no-unused-vars
 import should from 'should'
 import 'isomorphic-fetch'
-import {Cozy} from '../../src'
+import {Client} from '../../src'
 import {randomGenerator} from '../helpers'
 
 const COZY_STACK_URL = process.env && process.env.COZY_STACK_URL || ''
@@ -12,13 +12,13 @@ const COZY_STACK_TOKEN = process.env && process.env.COZY_STACK_TOKEN
 
 describe('references', async function () {
   let random
-  let cozy
+  const cozy = {}
 
   beforeEach(function () {
     if (COZY_STACK_VERSION === '2') {
       this.skip()
     }
-    cozy = new Cozy({
+    cozy.client = new Client({
       cozyURL: COZY_STACK_URL,
       token: COZY_STACK_TOKEN
     })
@@ -28,20 +28,20 @@ describe('references', async function () {
   it('bind files to a doc', async function () {
     const ids = []
     for (let i = 0; i < 3; i++) {
-      let file = await cozy.files.create('datastring1', {
+      let file = await cozy.client.files.create('datastring1', {
         name: 'foo_' + random(),
         contentType: 'application/json'
       })
       ids.push(file._id)
     }
 
-    const doc = await cozy.create('io.cozy.testreferencer', {
+    const doc = await cozy.client.create('io.cozy.testreferencer', {
       name: 'foo_' + random()
     })
 
-    await cozy.addReferencedFiles(doc, ids)
+    await cozy.client.addReferencedFiles(doc, ids)
 
-    const ids2 = await cozy.listReferencedFiles(doc)
+    const ids2 = await cozy.client.listReferencedFiles(doc)
     ids2.should.eql(ids)
   })
 })

--- a/test/integration/settings.js
+++ b/test/integration/settings.js
@@ -3,27 +3,27 @@
 // eslint-disable-next-line no-unused-vars
 import should from 'should'
 import 'isomorphic-fetch'
-import {Cozy} from '../../src'
+import {Client} from '../../src'
 
 const COZY_STACK_URL = process.env && process.env.COZY_STACK_URL || ''
 const COZY_STACK_VERSION = process.env && process.env.COZY_STACK_VERSION
 const COZY_STACK_TOKEN = process.env && process.env.COZY_STACK_TOKEN
 
 describe('settings api', async function () {
-  let cozy
+  const cozy = {}
 
   beforeEach(function () {
     if (COZY_STACK_VERSION === '2') {
       this.skip()
     }
-    cozy = new Cozy({
+    cozy.client = new Client({
       cozyURL: COZY_STACK_URL,
       token: COZY_STACK_TOKEN
     })
   })
 
   it('gets the disk usage', async function () {
-    const usage = await cozy.settings.diskUsage()
+    const usage = await cozy.client.settings.diskUsage()
     usage.should.have.property('attributes')
     usage.attributes.used.should.be.type('string')
   })

--- a/test/unit/auth.js
+++ b/test/unit/auth.js
@@ -2,16 +2,16 @@
 
 // eslint-disable-next-line no-unused-vars
 import should from 'should'
-import {Cozy, MemoryStorage} from '../../src'
+import {Client, MemoryStorage} from '../../src'
 import {oauthFlow, AccessToken} from '../../src/auth_v3'
 import mock from '../mock-api'
 import {decodeQuery} from '../../src/utils'
 
 describe('Authentication', function () {
-  let cozy
+  const cozy = {}
 
   beforeEach(() => {
-    cozy = new Cozy({
+    cozy.client = new Client({
       cozyURL: 'http://foobar/',
       token: 'apptoken'
     })
@@ -20,24 +20,24 @@ describe('Authentication', function () {
 
   describe('Client', function () {
     it('should be defined', function () {
-      cozy.auth.Client.should.be.type('function')
+      cozy.client.auth.Client.should.be.type('function')
     })
 
     it('should create a client', function () {
-      const client = new cozy.auth.Client({
+      const client = new cozy.client.auth.Client({
         redirectURI: 'http://coucou/',
         softwareID: 'id',
         clientName: 'client'
       })
 
-      client.should.be.instanceOf(cozy.auth.Client)
+      client.should.be.instanceOf(cozy.client.auth.Client)
       client.redirectURI.should.be.type('string')
       client.softwareID.should.be.type('string')
       client.clientName.should.be.type('string')
     })
 
     it('should create a client from API data', function () {
-      const client = new cozy.auth.Client({
+      const client = new cozy.client.auth.Client({
         client_id: '123',
         client_secret: '456',
         registration_access_token: '789',
@@ -81,7 +81,7 @@ describe('Authentication', function () {
     before(mock.mockAPI('AuthRegisterClient'))
 
     it('works', async function () {
-      const client = await cozy.auth.registerClient({
+      const client = await cozy.client.auth.registerClient({
         redirectURI: 'http://coucou/',
         softwareID: 'id',
         clientName: 'client'
@@ -97,14 +97,14 @@ describe('Authentication', function () {
     before(mock.mockAPI('AuthGetClient'))
 
     it('works', async function () {
-      cozy = new Cozy({
+      cozy.client = new Client({
         cozyURL: 'http://foobar/',
         token: 'apptoken'
       })
 
       const clientID = '123'
       const registrationAccessToken = '789'
-      const client = await cozy.auth.getClient({ clientID, registrationAccessToken })
+      const client = await cozy.client.auth.getClient({ clientID, registrationAccessToken })
 
       client.clientID.should.equal('123')
       client.clientSecret.should.equal('456')
@@ -117,7 +117,7 @@ describe('Authentication', function () {
 
   describe('getAuthCodeURL', function () {
     it('works', function () {
-      const client = new cozy.auth.Client({
+      const client = new cozy.client.auth.Client({
         client_id: '123',
         client_secret: '456',
         registration_access_token: '789',
@@ -131,7 +131,7 @@ describe('Authentication', function () {
         policy_uri: '123'
       })
 
-      const {url, state} = cozy.auth.getAuthCodeURL(client, ['a', 'b'])
+      const {url, state} = cozy.client.auth.getAuthCodeURL(client, ['a', 'b'])
       state.should.be.type('string')
       state.length.should.not.equal(0)
       url.indexOf('http://foobar/auth/authorize?').should.equal(0)
@@ -149,7 +149,7 @@ describe('Authentication', function () {
     before(mock.mockAPI('AccessToken'))
 
     it('works', async function () {
-      const client = new cozy.auth.Client({
+      const client = new cozy.client.auth.Client({
         client_id: '123',
         client_secret: '456',
         registration_access_token: '789',
@@ -163,10 +163,10 @@ describe('Authentication', function () {
         policy_uri: '123'
       })
 
-      const {url, state} = cozy.auth.getAuthCodeURL(client, ['a', 'b'])
+      const {url, state} = cozy.client.auth.getAuthCodeURL(client, ['a', 'b'])
 
-      const token = await cozy.auth.getAccessToken(client, state, url)
-      token.should.eql(new cozy.auth.AccessToken({
+      const token = await cozy.client.auth.getAccessToken(client, state, url)
+      token.should.eql(new cozy.client.auth.AccessToken({
         tokenType: 'Bearer',
         accessToken: '123',
         refreshToken: '456',
@@ -179,7 +179,7 @@ describe('Authentication', function () {
     before(mock.mockAPI('AccessToken'))
 
     it('works', async function () {
-      const client = new cozy.auth.Client({
+      const client = new cozy.client.auth.Client({
         client_id: '123',
         client_secret: '456',
         registration_access_token: '789',
@@ -193,15 +193,15 @@ describe('Authentication', function () {
         policy_uri: '123'
       })
 
-      const token1 = new cozy.auth.AccessToken({
+      const token1 = new cozy.client.auth.AccessToken({
         tokenType: 'Bearer',
         accessToken: '123',
         refreshToken: '456',
         scope: 'a b'
       })
 
-      const token2 = await cozy.auth.refreshToken(client, token1)
-      token2.should.eql(new cozy.auth.AccessToken({
+      const token2 = await cozy.client.auth.refreshToken(client, token1)
+      token2.should.eql(new cozy.client.auth.AccessToken({
         tokenType: 'Bearer',
         accessToken: '123',
         refreshToken: '456',
@@ -214,7 +214,7 @@ describe('Authentication', function () {
     before(mock.mockAPI('UpdateClient'))
 
     it('can update client data', async function () {
-      const client = new cozy.auth.Client({
+      const client = new cozy.client.auth.Client({
         client_id: '123',
         client_secret: '456',
         registration_access_token: '789',
@@ -230,7 +230,7 @@ describe('Authentication', function () {
 
       client.logoURI = '321'
 
-      let client2 = await cozy.auth.updateClient(client)
+      let client2 = await cozy.client.auth.updateClient(client)
       client2.clientID.should.eql('123')
       client2.logoURI.should.eql('321')
       client2.registrationAccessToken.should.eql('789')
@@ -244,7 +244,7 @@ describe('Authentication', function () {
     before(mock.mockAPI('ResetClientToken'))
 
     it('can reset client token', async function () {
-      const client = new cozy.auth.Client({
+      const client = new cozy.client.auth.Client({
         client_id: '123',
         client_secret: '456',
         registration_access_token: '789',
@@ -258,7 +258,7 @@ describe('Authentication', function () {
         policy_uri: '123'
       })
 
-      let client2 = await cozy.auth.updateClient(client, true)
+      let client2 = await cozy.client.auth.updateClient(client, true)
       client2.clientID.should.eql('123')
       client2.registrationAccessToken.should.eql('789')
 
@@ -273,7 +273,7 @@ describe('Authentication', function () {
     before(mock.mockAPI('UnregisterClient'))
 
     it('works', async function () {
-      const client = new cozy.auth.Client({
+      const client = new cozy.client.auth.Client({
         client_id: '123',
         client_secret: '456',
         registration_access_token: '789',
@@ -287,7 +287,7 @@ describe('Authentication', function () {
         policy_uri: '123'
       })
 
-      await cozy.auth.unregisterClient(client)
+      await cozy.client.auth.unregisterClient(client)
     })
   })
 
@@ -302,7 +302,7 @@ describe('Authentication', function () {
       const storage = new MemoryStorage()
       const err = new Error()
       oauthFlow(
-        cozy, storage,
+        cozy.client, storage,
         {
           redirectURI: 'http://babelu/',
           softwareID: 'id',
@@ -338,7 +338,7 @@ describe('Authentication', function () {
       let error
       try {
         await oauthFlow(
-          cozy, storage,
+          cozy.client, storage,
           () => {},
           () => 'http://coucou/?state=123'
         )
@@ -355,7 +355,7 @@ describe('Authentication', function () {
 
       function doRegistration () {
         return oauthFlow(
-          cozy, storage,
+          cozy.client, storage,
           {
             redirectURI: 'http://coucou/',
             softwareID: 'id',
@@ -371,7 +371,7 @@ describe('Authentication', function () {
 
       async function doThen () {
         const credentials = await oauthFlow(
-          cozy, storage,
+          cozy.client, storage,
           () => {},
           () => ''
         )
@@ -391,8 +391,8 @@ describe('Authentication', function () {
           throw new Error('should not have state anymore')
         }
 
-        creds.client.should.be.instanceOf(cozy.auth.Client)
-        creds.token.should.be.instanceOf(cozy.auth.AccessToken)
+        creds.client.should.be.instanceOf(cozy.client.auth.Client)
+        creds.token.should.be.instanceOf(cozy.client.auth.AccessToken)
         done()
       }
 
@@ -404,7 +404,7 @@ describe('Authentication', function () {
 
       function doRegistration () {
         return oauthFlow(
-          cozy, storage,
+          cozy.client, storage,
           {
             redirectURI: 'http://coucou/',
             softwareID: 'id',
@@ -420,10 +420,10 @@ describe('Authentication', function () {
 
       async function doThen () {
         const creds1 = await oauthFlow(
-          cozy, storage)
+          cozy.client, storage)
 
         const creds2 = await oauthFlow(
-          cozy, storage)
+          cozy.client, storage)
 
         creds2.should.eql(creds1)
         done()

--- a/test/unit/crud.js
+++ b/test/unit/crud.js
@@ -2,14 +2,14 @@
 
 // eslint-disable-next-line no-unused-vars
 import should from 'should'
-import {Cozy} from '../../src'
+import {Client} from '../../src'
 import mock from '../mock-api'
 
 describe('crud API', function () {
-  let cozy
+  const cozy = {}
 
   beforeEach(() => {
-    cozy = new Cozy({
+    cozy.client = new Client({
       cozyURL: 'http://my.cozy.io///',
       token: 'apptoken'
     })
@@ -21,7 +21,7 @@ describe('crud API', function () {
 
     it('Call the proper route', async function () {
       const testDoc = { 'test': 'value' }
-      const created = await cozy.create('io.cozy.testobject', testDoc)
+      const created = await cozy.client.create('io.cozy.testobject', testDoc)
 
       mock.calls('CreateDoc').should.have.length(1)
       mock.lastUrl('CreateDoc').should.equal('http://my.cozy.io/data/io.cozy.testobject/')
@@ -39,7 +39,7 @@ describe('crud API', function () {
     before(mock.mockAPI('GetDoc'))
 
     it('Call the proper route', async function () {
-      let fetched = await cozy.find('io.cozy.testobject', '42')
+      let fetched = await cozy.client.find('io.cozy.testobject', '42')
 
       mock.calls('GetDoc').should.have.length(1)
       mock.lastUrl('GetDoc').should.equal('http://my.cozy.io/data/io.cozy.testobject/42')
@@ -56,7 +56,7 @@ describe('crud API', function () {
 
     it('Call the proper route', async function () {
       const changes = { 'test': 'value2' }
-      const updated = await cozy.update('io.cozy.testobject', { _id: '42', _rev: '1-5444878785445' }, changes)
+      const updated = await cozy.client.update('io.cozy.testobject', { _id: '42', _rev: '1-5444878785445' }, changes)
 
       mock.calls('UpdateDoc').should.have.length(1)
       mock.lastUrl('UpdateDoc').should.equal('http://my.cozy.io/data/io.cozy.testobject/42')
@@ -75,7 +75,7 @@ describe('crud API', function () {
       const changes = { 'test': 'value2' }
 
       try {
-        await cozy.update('io.cozy.testobject', { _rev: '1-5444878785445' }, changes)
+        await cozy.client.update('io.cozy.testobject', { _rev: '1-5444878785445' }, changes)
       } catch (e) {
         err = e
       } finally {
@@ -85,7 +85,7 @@ describe('crud API', function () {
       err = null
 
       try {
-        await cozy.update('io.cozy.testobject', { _id: '42' }, changes)
+        await cozy.client.update('io.cozy.testobject', { _id: '42' }, changes)
       } catch (e) {
         err = e
       } finally {
@@ -98,7 +98,7 @@ describe('crud API', function () {
     before(mock.mockAPI('DeleteDoc'))
 
     it('Call the proper route', async function () {
-      const deleted = await cozy.delete('io.cozy.testobject', { _id: '42', _rev: '1-5444878785445' })
+      const deleted = await cozy.client.delete('io.cozy.testobject', { _id: '42', _rev: '1-5444878785445' })
 
       mock.calls('DeleteDoc').should.have.length(1)
       mock.lastUrl('DeleteDoc').should.equal('http://my.cozy.io/data/io.cozy.testobject/42?rev=1-5444878785445')

--- a/test/unit/files.js
+++ b/test/unit/files.js
@@ -3,14 +3,14 @@
 // eslint-disable-next-line no-unused-vars
 import should from 'should'
 import { Readable } from 'stream'
-import {Cozy} from '../../src'
+import {Client} from '../../src'
 import mock from '../mock-api'
 
 describe('Files', function () {
-  let cozy
+  const cozy = {}
 
   beforeEach(() => {
-    cozy = new Cozy({
+    cozy.client = new Client({
       cozyURL: 'http://my.cozy.io///',
       token: 'apptoken'
     })
@@ -27,10 +27,10 @@ describe('Files', function () {
       stream.push('somestreamdata')
       stream.push(null)
 
-      const res1 = await cozy.files.create('somestringdata', { name: 'foo', dirID: '12345', contentType: 'text/html' })
-      const res2 = await cozy.files.create(new Uint8Array(10), { name: 'foo', dirID: '12345', lastModifiedDate: date })
-      const res3 = await cozy.files.create(stream, { name: 'foo', dirID: '12345', contentType: 'text/plain' })
-      const res4 = await cozy.files.create(new ArrayBuffer(10), { name: 'foo', dirID: '12345' })
+      const res1 = await cozy.client.files.create('somestringdata', { name: 'foo', dirID: '12345', contentType: 'text/html' })
+      const res2 = await cozy.client.files.create(new Uint8Array(10), { name: 'foo', dirID: '12345', lastModifiedDate: date })
+      const res3 = await cozy.client.files.create(stream, { name: 'foo', dirID: '12345', contentType: 'text/plain' })
+      const res4 = await cozy.client.files.create(new ArrayBuffer(10), { name: 'foo', dirID: '12345' })
 
       const calls = mock.calls('UploadFile')
       calls.should.have.length(4)
@@ -48,7 +48,7 @@ describe('Files', function () {
       let err = null
 
       try {
-        await cozy.files.create(1, { name: 'name' })
+        await cozy.client.files.create(1, { name: 'name' })
       } catch (e) {
         err = e
       } finally {
@@ -58,7 +58,7 @@ describe('Files', function () {
       err = null
 
       try {
-        await cozy.files.create({}, { name: 'name' })
+        await cozy.client.files.create({}, { name: 'name' })
       } catch (e) {
         err = e
       } finally {
@@ -68,7 +68,7 @@ describe('Files', function () {
       err = null
 
       try {
-        await cozy.files.create('', { name: 'name' })
+        await cozy.client.files.create('', { name: 'name' })
       } catch (e) {
         err = e
       } finally {
@@ -78,7 +78,7 @@ describe('Files', function () {
       err = null
 
       try {
-        await cozy.files.create('somestringdata')
+        await cozy.client.files.create('somestringdata')
       } catch (e) {
         err = e
       } finally {
@@ -88,7 +88,7 @@ describe('Files', function () {
       err = null
 
       try {
-        await cozy.files.updateById('12345', 1)
+        await cozy.client.files.updateById('12345', 1)
       } catch (e) {
         err = e
       } finally {
@@ -98,7 +98,7 @@ describe('Files', function () {
       err = null
 
       try {
-        await cozy.files.updateById('12345', {})
+        await cozy.client.files.updateById('12345', {})
       } catch (e) {
         err = e
       } finally {
@@ -108,7 +108,7 @@ describe('Files', function () {
       err = null
 
       try {
-        await cozy.files.updateById('12345', '')
+        await cozy.client.files.updateById('12345', '')
       } catch (e) {
         err = e
       } finally {
@@ -125,10 +125,10 @@ describe('Files', function () {
     it('should work', async function () {
       const dateString = 'Wed, 01 Feb 2017 10:24:42 GMT'
       const date = new Date(dateString)
-      const res1 = await cozy.files.createDirectory({ name: 'foo' })
-      const res2 = await cozy.files.createDirectory({ name: 'foo', lastModifiedDate: date })
-      const res3 = await cozy.files.createDirectory({ name: 'foo', lastModifiedDate: dateString })
-      const res4 = await cozy.files.createDirectory({ name: 'foo', dirID: '12345' })
+      const res1 = await cozy.client.files.createDirectory({ name: 'foo' })
+      const res2 = await cozy.client.files.createDirectory({ name: 'foo', lastModifiedDate: date })
+      const res3 = await cozy.client.files.createDirectory({ name: 'foo', lastModifiedDate: dateString })
+      const res4 = await cozy.client.files.createDirectory({ name: 'foo', dirID: '12345' })
 
       const calls = mock.calls('CreateDirectory')
       calls.should.have.length(4)
@@ -146,7 +146,7 @@ describe('Files', function () {
       let err = null
 
       try {
-        await cozy.files.createDirectory(null)
+        await cozy.client.files.createDirectory(null)
       } catch (e) {
         err = e
       } finally {
@@ -156,7 +156,7 @@ describe('Files', function () {
       err = null
 
       try {
-        await cozy.files.createDirectory({})
+        await cozy.client.files.createDirectory({})
       } catch (e) {
         err = e
       } finally {
@@ -166,7 +166,7 @@ describe('Files', function () {
       err = null
 
       try {
-        await cozy.files.createDirectory({ name: '' })
+        await cozy.client.files.createDirectory({ name: '' })
       } catch (e) {
         err = e
       } finally {
@@ -181,7 +181,7 @@ describe('Files', function () {
     before(mock.mockAPI('Trash'))
 
     it('should work', async function () {
-      const res1 = await cozy.files.trashById('1234')
+      const res1 = await cozy.client.files.trashById('1234')
 
       mock.calls('Trash').should.have.length(1)
       mock.lastUrl('Trash').should.equal('http://my.cozy.io/files/1234')
@@ -193,7 +193,7 @@ describe('Files', function () {
       let err = null
 
       try {
-        await cozy.files.trashById(null)
+        await cozy.client.files.trashById(null)
       } catch (e) {
         err = e
       } finally {
@@ -203,7 +203,7 @@ describe('Files', function () {
       err = null
 
       try {
-        await cozy.files.trashById({})
+        await cozy.client.files.trashById({})
       } catch (e) {
         err = e
       } finally {
@@ -213,7 +213,7 @@ describe('Files', function () {
       err = null
 
       try {
-        await cozy.files.trashById('')
+        await cozy.client.files.trashById('')
       } catch (e) {
         err = e
       } finally {
@@ -230,11 +230,11 @@ describe('Files', function () {
     it('should work with good arguments', async function () {
       const attrs = { tags: ['foo', 'bar'] }
 
-      const res1 = await cozy.files.updateAttributesById('12345', attrs)
+      const res1 = await cozy.client.files.updateAttributesById('12345', attrs)
       mock.lastUrl('UpdateAttributes').should.equal('http://my.cozy.io/files/12345')
       JSON.parse(mock.lastOptions('UpdateAttributes').body).should.eql({data: { attributes: attrs }})
 
-      const res2 = await cozy.files.updateAttributesByPath('/foo/bar', attrs)
+      const res2 = await cozy.client.files.updateAttributesByPath('/foo/bar', attrs)
       mock.lastUrl('UpdateAttributes').should.equal('http://my.cozy.io/files/metadata?Path=%2Ffoo%2Fbar')
       JSON.parse(mock.lastOptions('UpdateAttributes').body).should.eql({data: { attributes: attrs }})
 
@@ -248,7 +248,7 @@ describe('Files', function () {
       let err = null
 
       try {
-        await cozy.files.updateAttributesById('12345', null)
+        await cozy.client.files.updateAttributesById('12345', null)
       } catch (e) {
         err = e
       } finally {
@@ -258,7 +258,7 @@ describe('Files', function () {
       err = null
 
       try {
-        await cozy.files.updateAttributesByPath('/12345', null)
+        await cozy.client.files.updateAttributesByPath('/12345', null)
       } catch (e) {
         err = e
       } finally {
@@ -273,7 +273,7 @@ describe('Files', function () {
     before(mock.mockAPI('StatByID'))
 
     it('should work', async function () {
-      const res1 = await cozy.files.statById('id42')
+      const res1 = await cozy.client.files.statById('id42')
 
       mock.calls('StatByID').should.have.length(1)
       mock.lastUrl('StatByID').should.equal('http://my.cozy.io/files/id42')
@@ -289,7 +289,7 @@ describe('Files', function () {
     before(mock.mockAPI('StatByPath'))
 
     it('should work', async function () {
-      const res1 = await cozy.files.statByPath('/bills/hôpital.pdf')
+      const res1 = await cozy.client.files.statByPath('/bills/hôpital.pdf')
 
       mock.calls('StatByPath').should.have.length(1)
       mock.lastUrl('StatByPath').should.equal('http://my.cozy.io/files/metadata?Path=%2Fbills%2Fh%C3%B4pital.pdf')
@@ -306,7 +306,7 @@ describe('Files', function () {
       before(mock.mockAPI('DownloadByID'))
 
       it('should work', async function () {
-        const res = await cozy.files.downloadById('id42')
+        const res = await cozy.client.files.downloadById('id42')
 
         mock.calls('DownloadByID').should.have.length(1)
         mock.lastUrl('DownloadByID').should.equal('http://my.cozy.io/files/download/id42')
@@ -321,7 +321,7 @@ describe('Files', function () {
       before(mock.mockAPI('DownloadByPath'))
 
       it('should work', async function () {
-        const res = await cozy.files.downloadByPath('/bills/hôpital.pdf')
+        const res = await cozy.client.files.downloadByPath('/bills/hôpital.pdf')
 
         mock.calls('DownloadByPath').should.have.length(1)
         mock.lastUrl('DownloadByPath').should.equal('http://my.cozy.io/files/download?Path=%2Fbills%2Fh%C3%B4pital.pdf')

--- a/test/unit/mango.js
+++ b/test/unit/mango.js
@@ -2,15 +2,15 @@
 
 // eslint-disable-next-line no-unused-vars
 import should from 'should'
-import {Cozy} from '../../src'
+import {Client} from '../../src'
 import mock from '../mock-api'
 
 describe('mango API', function () {
   let indexRef
-  let cozy
+  const cozy = {}
 
   beforeEach(() => {
-    cozy = new Cozy({
+    cozy.client = new Client({
       cozyURL: 'http://my.cozy.io///',
       token: 'apptoken'
     })
@@ -23,7 +23,7 @@ describe('mango API', function () {
 
     it('Call the proper route', async function () {
       const testIndex = ['field1', 'field2']
-      indexRef = await cozy.defineIndex('io.cozy.testobject', testIndex)
+      indexRef = await cozy.client.defineIndex('io.cozy.testobject', testIndex)
 
       mock.calls('CreateIndex').should.have.length(1)
       mock.lastUrl('CreateIndex').should.equal('http://my.cozy.io/data/io.cozy.testobject/_index')
@@ -43,7 +43,7 @@ describe('mango API', function () {
     before(mock.mockAPI('FindDocuments'))
 
     it('Call the proper route', async function () {
-      let fetched = await cozy.query(indexRef, {
+      let fetched = await cozy.client.query(indexRef, {
         selector: {field1: 'value'}
       })
 

--- a/test/unit/offline.js
+++ b/test/unit/offline.js
@@ -2,7 +2,7 @@
 
 // eslint-disable-next-line no-unused-vars
 import should from 'should'
-import {Cozy} from '../../src'
+import {Client} from '../../src'
 import PouchDB from 'pouchdb'
 PouchDB.plugin(require('pouchdb-adapter-memory'))
 
@@ -11,89 +11,89 @@ describe('offline', () => {
   const otherDoctype = 'io.cozy.others'
   const cozyUrl = 'http://cozy.local:8080/'
   let offlineParameter = {doctypes: [fileDoctype, otherDoctype], options: {adapter: 'memory'}}
-  let cozy
+  const cozy = {}
 
   describe('Initialise offline', () => {
     it('is disable by default', () => {
-      cozy = new Cozy({
+      cozy.client = new Client({
         cozyURL: cozyUrl,
         token: 'apptoken'
       })
-      const isNotDefined = cozy._offline === null
+      const isNotDefined = cozy.client._offline === null
       isNotDefined.should.be.true
     })
 
     it('create couchdb database for each doctype', () => {
-      cozy = new Cozy({
+      cozy.client = new Client({
         cozyURL: cozyUrl,
         offline: offlineParameter,
         token: 'apptoken'
       })
-      cozy._offline.should.be.an.Array()
-      cozy._offline.should.have.property(fileDoctype)
-      cozy._offline.should.have.property(otherDoctype)
-      cozy._offline[fileDoctype].database.should.be.an.instanceof(PouchDB)
-      cozy._offline[otherDoctype].database.should.be.an.instanceof(PouchDB)
+      cozy.client._offline.should.be.an.Array()
+      cozy.client._offline.should.have.property(fileDoctype)
+      cozy.client._offline.should.have.property(otherDoctype)
+      cozy.client._offline[fileDoctype].database.should.be.an.instanceof(PouchDB)
+      cozy.client._offline[otherDoctype].database.should.be.an.instanceof(PouchDB)
     })
 
     it('is possible to enable after cozy init', () => {
-      cozy = new Cozy({
+      cozy.client = new Client({
         cozyURL: cozyUrl,
         token: 'apptoken'
       })
-      cozy.offline.createDatabase(fileDoctype, {adapter: 'memory'})
-      cozy._offline.should.be.an.Array()
-      cozy._offline.should.have.property(fileDoctype)
+      cozy.client.offline.createDatabase(fileDoctype, {adapter: 'memory'})
+      cozy.client._offline.should.be.an.Array()
+      cozy.client._offline.should.have.property(fileDoctype)
     })
   })
 
   describe('doctype database', () => {
     beforeEach(() => {
-      cozy = new Cozy({
+      cozy.client = new Client({
         cozyURL: cozyUrl,
         token: 'apptoken'
       })
     })
 
     it('should create database', () => {
-      let db = cozy.offline.createDatabase(fileDoctype, {adapter: 'memory'})
+      let db = cozy.client.offline.createDatabase(fileDoctype, {adapter: 'memory'})
       db.name.should.be.equal(fileDoctype)
       db.should.be.an.instanceof(PouchDB)
     })
 
     it('should verify database exist', () => {
-      cozy.offline.hasDatabase(fileDoctype).should.be.false
-      cozy.offline.createDatabase(fileDoctype, {adapter: 'memory'})
-      cozy.offline.hasDatabase(fileDoctype).should.be.true
+      cozy.client.offline.hasDatabase(fileDoctype).should.be.false
+      cozy.client.offline.createDatabase(fileDoctype, {adapter: 'memory'})
+      cozy.client.offline.hasDatabase(fileDoctype).should.be.true
     })
 
     it('should get database', () => {
-      should.not.exist(cozy.offline.getDatabase(fileDoctype))
-      cozy.offline.createDatabase(fileDoctype, {adapter: 'memory'})
-      let db = cozy.offline.getDatabase(fileDoctype)
+      should.not.exist(cozy.client.offline.getDatabase(fileDoctype))
+      cozy.client.offline.createDatabase(fileDoctype, {adapter: 'memory'})
+      let db = cozy.client.offline.getDatabase(fileDoctype)
       db.name.should.be.equal(fileDoctype)
       db.should.be.an.instanceof(PouchDB)
     })
 
     it('should destroy database', async () => {
-      await cozy.offline.createDatabase(fileDoctype, {adapter: 'memory'})
-      cozy.offline.hasDatabase(fileDoctype).should.be.true
-      await cozy.offline.destroyDatabase(fileDoctype)
-      cozy.offline.hasDatabase(fileDoctype).should.be.false
+      await cozy.client.offline.createDatabase(fileDoctype, {adapter: 'memory'})
+      cozy.client.offline.hasDatabase(fileDoctype).should.be.true
+      await cozy.client.offline.destroyDatabase(fileDoctype)
+      cozy.client.offline.hasDatabase(fileDoctype).should.be.false
     })
 
     it('should return doctypes', () => {
       // no offline
-      cozy.offline.getDoctypes().should.be.eql([])
+      cozy.client.offline.getDoctypes().should.be.eql([])
       // with one or more doctype offline
-      cozy.offline.createDatabase(fileDoctype, {adapter: 'memory'})
-      cozy.offline.getDoctypes().should.be.eql([fileDoctype])
-      cozy.offline.createDatabase(otherDoctype, {adapter: 'memory'})
-      cozy.offline.getDoctypes().should.be.eql([fileDoctype, otherDoctype])
+      cozy.client.offline.createDatabase(fileDoctype, {adapter: 'memory'})
+      cozy.client.offline.getDoctypes().should.be.eql([fileDoctype])
+      cozy.client.offline.createDatabase(otherDoctype, {adapter: 'memory'})
+      cozy.client.offline.getDoctypes().should.be.eql([fileDoctype, otherDoctype])
     })
 
     it('should create mongo index when create database', async () => {
-      let db = cozy.offline.createDatabase(fileDoctype, {adapter: 'memory'})
+      let db = cozy.client.offline.createDatabase(fileDoctype, {adapter: 'memory'})
       await db.getIndexes().then(result => {
         result.indexes.length.should.exactly(1)
       })
@@ -102,7 +102,7 @@ describe('offline', () => {
 
   describe('sync database', () => {
     beforeEach(() => {
-      cozy = new Cozy({
+      cozy.client = new Client({
         cozyURL: cozyUrl,
         offline: offlineParameter,
         token: 'apptoken'
@@ -110,32 +110,32 @@ describe('offline', () => {
     })
 
     it('is disable by default', () => {
-      cozy.offline.hasSync(fileDoctype).should.be.false
+      cozy.client.offline.hasSync(fileDoctype).should.be.false
     })
 
     it('should be enable all on init and stop all sync', () => {
-      cozy.offline.hasSync(fileDoctype).should.be.false
-      cozy.offline.hasSync(otherDoctype).should.be.false
+      cozy.client.offline.hasSync(fileDoctype).should.be.false
+      cozy.client.offline.hasSync(otherDoctype).should.be.false
       let copy = JSON.parse(JSON.stringify(offlineParameter))
       copy.timer = 10
-      cozy = new Cozy({
+      cozy.client = new Client({
         cozyURL: cozyUrl,
         offline: copy,
         token: 'apptoken'
       })
-      cozy.offline.hasSync(fileDoctype).should.be.true
-      cozy.offline.hasSync(otherDoctype).should.be.true
-      cozy.offline.stopAllSync()
-      cozy.offline.hasSync(fileDoctype).should.be.false
-      cozy.offline.hasSync(otherDoctype).should.be.false
+      cozy.client.offline.hasSync(fileDoctype).should.be.true
+      cozy.client.offline.hasSync(otherDoctype).should.be.true
+      cozy.client.offline.stopAllSync()
+      cozy.client.offline.hasSync(fileDoctype).should.be.false
+      cozy.client.offline.hasSync(otherDoctype).should.be.false
     })
 
     it('should be enable after init and stop it', () => {
-      cozy.offline.hasSync(fileDoctype).should.be.false
-      cozy.offline.startSync(fileDoctype)
-      cozy.offline.hasSync(fileDoctype).should.be.true
-      cozy.offline.stopSync(fileDoctype)
-      cozy.offline.hasSync(fileDoctype).should.be.false
+      cozy.client.offline.hasSync(fileDoctype).should.be.false
+      cozy.client.offline.startSync(fileDoctype)
+      cozy.client.offline.hasSync(fileDoctype).should.be.true
+      cozy.client.offline.stopSync(fileDoctype)
+      cozy.client.offline.hasSync(fileDoctype).should.be.false
     })
   })
 })

--- a/test/unit/settings.js
+++ b/test/unit/settings.js
@@ -2,14 +2,14 @@
 
 // eslint-disable-next-line no-unused-vars
 import should from 'should'
-import {Cozy} from '../../src'
+import {Client} from '../../src'
 import mock from '../mock-api'
 
 describe('settings', function () {
-  let cozy
+  const cozy = {}
 
   beforeEach(() => {
-    cozy = new Cozy({
+    cozy.client = new Client({
       cozyURL: 'http://my.cozy.io///',
       token: 'apptoken'
     })
@@ -20,7 +20,7 @@ describe('settings', function () {
     before(mock.mockAPI('DiskUsage'))
 
     it('should work', async function () {
-      const usage = await cozy.settings.diskUsage()
+      const usage = await cozy.client.settings.diskUsage()
       usage._id.should.equal('io.cozy.settings.disk-usage')
       usage._type.should.equal('io.cozy.settings')
       usage.attributes.used.should.equal('123')

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -11,13 +11,17 @@ var output = {
 }
 
 if (NODE_TARGET === 'web') {
-  output.filename = 'cozy-client.js'
-  output.library = 'cozy-client-js'
-  output.libraryTarget = 'umd'
-  output.umdNamedDefine = true
+  Object.assign(output, {
+    filename: 'cozy-client.js',
+    library: ['cozy', 'client'],
+    libraryTarget: 'umd',
+    umdNamedDefine: true
+  })
 } else {
-  output.filename = 'cozy-client.node.js'
-  output.libraryTarget = 'commonjs'
+  Object.assign(output, {
+    filename: 'cozy-client.node.js',
+    libraryTarget: 'commonjs'
+  })
 }
 
 var config = {
@@ -25,6 +29,14 @@ var config = {
   devtool: 'source-map',
   target: NODE_TARGET,
   output: output,
+  externals: {
+    pouchdb: 'pouchdb',
+    'pouchdb-find': 'pouchdb-find'
+  },
+  resolve: {
+    root: path.resolve('./src'),
+    extensions: ['', '.js']
+  },
   module: {
     loaders: [
       {
@@ -41,14 +53,6 @@ var config = {
   },
   node: {
     'crypto': false
-  },
-  resolve: {
-    root: path.resolve('./src'),
-    extensions: ['', '.js']
-  },
-  externals: {
-    pouchdb: 'pouchdb',
-    'pouchdb-find': 'pouchdb-find'
   }
 }
 


### PR DESCRIPTION
This PR ensure we build a real UMD module, and exposes it at root level under the namespace `cozy` (i.e. `window.cozy.client`)