### PR TITLE
[chore] Updated namespace in docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -67,7 +67,7 @@ All cozy-client-js functions support callback or promise.
 
 If no callback is provided, a promise is returned.
 ```javascript
-cozy.data.create(myBooksDoctype, doc)
+cozy.client.data.create(myBooksDoctype, doc)
     .then(function(result){ console.log('done', result); });
     .catch(function(err){ console.log('fail', err); });
 ```
@@ -75,7 +75,7 @@ cozy.data.create(myBooksDoctype, doc)
 If your build pipeline supports it, use async/await for sweet sweet async
 ```javascript
 try {
-  result = await cozy.data.create(myBooksDoctype, doc)
+  result = await cozy.client.data.create(myBooksDoctype, doc)
   console.log('done', result)
 } catch(err) {
   console.log('fail', err)
@@ -85,8 +85,8 @@ try {
 If for some reason you do not want to use promises, you can pass the `disablePromises` flag to the init function. This way, you will be able to use the functions with a classic callback.
 
 ```javascript
-cozy.init({ disablePromises: true })
-cozy.data.create(myBooksDoctype, doc, function(err, result) {
+cozy.client.init({ disablePromises: true })
+cozy.client.data.create(myBooksDoctype, doc, function(err, result) {
     if (err) {
       console.log('fail', err);
     } else {
@@ -100,18 +100,18 @@ cozy.data.create(myBooksDoctype, doc, function(err, result) {
 ## Constructor
 
 
-### `new Cozy(options)`
+### `new cozy.Client(options)`
 
-`new Cozy(options)` returns a new cozy client.
+`new cozy.Client(options)` returns a new cozy client.
 
 It does return a Cozy instance.
 
-It takes the same options object as the `cozy.init(options)` function.
+It takes the same options object as the `cozy.client.init(options)` function.
 
 
-### `cozy.init(options)`
+### `cozy.client.init(options)`
 
-`cozy.init(options)` setups initialize the global cozy instance.
+`cozy.client.init(options)` setups initialize the global cozy instance.
 
 It does not return a value.
 
@@ -121,7 +121,7 @@ It does not return a value.
   * `oauth`: an object with the OAuth parameters, see [OAuth](./oauth.md) for details
 
 ```javascript
-cozy.init({
+cozy.client.init({
   cozyURL: 'http://my.cozy.local',
   disablePromises: false,
   oauth: {
@@ -136,9 +136,9 @@ cozy.init({
 
 ## Data API
 
-### `cozy.data.create(doctype, attributes)`
+### `cozy.client.data.create(doctype, attributes)`
 
-`cozy.data.create(doctype, attributes)` adds a document to the database.
+`cozy.client.data.create(doctype, attributes)` adds a document to the database.
 
 It returns a promise for the created object. The created object has the same attributes than passed with an added `_id`. It's the unique identifier for the created document.
 
@@ -152,7 +152,7 @@ If you use an existing doctype, you should follow its expected format. **v2** do
 ```javascript
 // simple object
 const book = { title: "Moby Dick", author:"Herman Melville", isbn: "42" }
-const created = await cozy.data.create(myBooksDoctype, book)
+const created = await cozy.client.data.create(myBooksDoctype, book)
 // same fields
 console.log(created.title, created.author, created.isbn)
 // _id, _rev are added
@@ -162,9 +162,9 @@ createdBookId = created._id
 ```
 
 
-### `cozy.data.find(doctype, id)`
+### `cozy.client.data.find(doctype, id)`
 
-`cozy.data.find(doctype, id)` returns the document associated to the given ID.
+`cozy.client.data.find(doctype, id)` returns the document associated to the given ID.
 
 It returns a promise for the document. It will have the same fields as the return value from `create`, including `_id` and `_rev`.
 
@@ -174,14 +174,14 @@ If the document does not exist, the promise will reject or the callback will be 
 - `id` is a string specifying the identifier of the document you search for
 
 ```javascript
-const doc = await cozy.data.find(myBooksDoctype, createdBookId)
+const doc = await cozy.client.data.find(myBooksDoctype, createdBookId)
 console.log(doc._id, doc._rev, doc.title, doc.author, doc.isbn)
 ```
 
 
-### `cozy.data.changesFeed(doctype, options)`
+### `cozy.client.data.changesFeed(doctype, options)`
 
-`cozy.data.changesFeed(doctype, options)` returns the last changes from CouchDB for the given doctype
+`cozy.client.data.changesFeed(doctype, options)` returns the last changes from CouchDB for the given doctype
 
 It returns a promise for the changes.
 
@@ -189,14 +189,14 @@ It returns a promise for the changes.
 - `options` is an object, only its `since` parameter is supported currently
 
 ```javascript
-const changes = await.cozy.data.changesFeed(myBooksDoctype, { since: 0 })
+const changes = await.cozy.client.data.changesFeed(myBooksDoctype, { since: 0 })
 console.log(changes.last_seq, changes.results)
 ```
 
 
-### `cozy.data.update(doctype, doc, newdoc)`
+### `cozy.client.data.update(doctype, doc, newdoc)`
 
-`cozy.data.update(doctype, doc, newdoc)` replaces the document by a new version.
+`cozy.client.data.update(doctype, doc, newdoc)` replaces the document by a new version.
 
 It returns a promise for the updated document. The updated document will have the same fields and values than provided newdoc, the same `_id` than doc, and a `_rev` incremented from doc's number.
 
@@ -210,7 +210,7 @@ If the document current `_rev` does not match the passed one, it means there is 
 
 ```javascript
 const updates = { title: "Moby Dick !", author:"THE Herman Melville"}
-const updated = await cozy.data.update(myBooksDoctype, doc, updates)
+const updated = await cozy.client.data.update(myBooksDoctype, doc, updates)
 console.log(updated._id === doc._id) // _id does not change
 console.log(updated._rev) // 2-xxxxxx
 console.log(updated.title, updated.year) // fields are changed
@@ -218,9 +218,9 @@ console.log(updated.isbn === undefined) // update erase fields
 ```
 
 
-### `cozy.data.updateAttributes(doctype, id, changes)`
+### `cozy.client.data.updateAttributes(doctype, id, changes)`
 
-`cozy.data.updateAttributes(doctype, id, changes)` applies change to the document.
+`cozy.client.data.updateAttributes(doctype, id, changes)` applies change to the document.
 
 It returns a promise for the updated document. The updated document will be the result of merging changes into the document with given `_id` and a incremented `_rev`.
 
@@ -234,7 +234,7 @@ This function gives 3 attempts not to conflict.
 
 ```javascript
 const updates = { year: 1852}
-const updated = await cozy.data.updateAttributes(myBooksDoctype, id, updates)
+const updated = await cozy.client.data.updateAttributes(myBooksDoctype, id, updates)
 console.log(updated._id === doc._id) // _id does not change
 console.log(updated._rev) // 3-xxxxxx
 console.log(updated.year) // fields are changed
@@ -242,9 +242,9 @@ console.log(updated.isbn) // updateAttributes preserve other fields
 ```
 
 
-### `cozy.data.delete(doctype, doc)`
+### `cozy.client.data.delete(doctype, doc)`
 
-`cozy.data.delete(doctype, doc )` will erase the document from the database.
+`cozy.client.data.delete(doctype, doc )` will erase the document from the database.
 
 It returns a promise which will resolve when the document has been deleted.
 
@@ -254,13 +254,13 @@ If the document does not exist, the promise will reject with an error. If the do
 - `doc` is an object with *at least* the fields `_id` and `_rev` containing the identifier and revision of the file you want to destroy.
 
 ```javascript
-await cozy.data.delete(myBooksDoctype, updated)
+await cozy.client.data.delete(myBooksDoctype, updated)
 ```
 
 
-### `cozy.data.defineIndex(doctype, fields)`
+### `cozy.client.data.defineIndex(doctype, fields)`
 
-`cozy.data.defineIndex(doctype, fields)` creates an index for a document type. It is idempotent, it can be called several time with no bad effect.
+`cozy.client.data.defineIndex(doctype, fields)` creates an index for a document type. It is idempotent, it can be called several time with no bad effect.
 
 It returns a promise for an **indexReference**, which can be passed to `cozy.data.query`.
 
@@ -270,13 +270,13 @@ It returns a promise for an **indexReference**, which can be passed to `cozy.dat
 **Warning**: when used on **v2**, a map-reduce view is created internally, when used on **v3**, we use couchdb built-in mango queries. Because of this, more complex queries are not (yet) supported with **v2**.
 
 ```javascript
-const booksByYearRef = await cozy.data.defineIndex(myType, ['year', 'rating'])
+const booksByYearRef = await cozy.client.data.defineIndex(myType, ['year', 'rating'])
 ```
 
 
-### `cozy.data.query(indexReference, query)`
+### `cozy.client.data.query(indexReference, query)`
 
-`cozy.data.query(indexReference, query)` find documents using an index.
+`cozy.client.data.query(indexReference, query)` find documents using an index.
 
 It returns a promise with a list of documents matching the query. Results will be returned in order according to the index.
 
@@ -288,7 +288,7 @@ It returns a promise with a list of documents matching the query. Results will b
 **Warning**: complex mango queries are not, and may never be compatible with **v2**
 
 ```javascript
-const results = await cozy.data.query(booksByYearRef, {
+const results = await cozy.client.data.query(booksByYearRef, {
   "selector": {year: 1851},
   "limit": 3,
   "skip": 1
@@ -303,9 +303,9 @@ resuts[0].rating < 2 // lowest rating first
 
 ## Files API
 
-### `cozy.files.create(data, options)`
+### `cozy.client.files.create(data, options)`
 
-`cozy.files.create(data, options)` is used to upload a new file onto your cozy
+`cozy.client.files.create(data, options)` is used to upload a new file onto your cozy
 
 It returns a promise for the document of the file created.
 
@@ -320,11 +320,11 @@ It returns a promise for the document of the file created.
 **Warning**: this API is not v2 compatible.
 
 ```javascript
-const created = await cozy.files.create(blob, {
+const created = await cozy.client.files.create(blob, {
     name: "filename",
     dirID: "123456",
 })
-const fileCreated = await cozy.files.create(fileInput.files[0], {
+const fileCreated = await cozy.client.files.create(fileInput.files[0], {
   dirID: "",
   checksum: "rL0Y20zC+Fzt72VPzMSk2A==",
   lastModifiedDate: new Date()
@@ -332,9 +332,9 @@ const fileCreated = await cozy.files.create(fileInput.files[0], {
 ```
 
 
-### `cozy.files.createDirectory(options)`
+### `cozy.client.files.createDirectory(options)`
 
-`cozy.files.createDirectory(options)` is used to create a new directory.
+`cozy.client.files.createDirectory(options)` is used to create a new directory.
 
 It returns a promise for the document of the directory created.
 
@@ -344,7 +344,7 @@ It returns a promise for the document of the directory created.
   * `lastModifiedDate`: a date to specify the last modification time to use for the directory.
 
 ```javascript
-const created = await cozy.files.createDirectory({
+const created = await cozy.client.files.createDirectory({
   name: "mydir",
   dirID: "123456",
   lastModifiedDate: new Date()
@@ -352,9 +352,9 @@ const created = await cozy.files.createDirectory({
 ```
 
 
-### `cozy.files.updateById(id, data, options)`
+### `cozy.client.files.updateById(id, data, options)`
 
-`cozy.files.updateById(id, data, options)` is used to update the content of an already existing file.
+`cozy.client.files.updateById(id, data, options)` is used to update the content of an already existing file.
 
 It returns a promise for the document of the file updated.
 
@@ -367,7 +367,7 @@ It returns a promise for the document of the file updated.
   * `ifMatch`: the previous revision of the file (optional). The update will be rejected if the remote revision doesn't match the given one.
 
 ```javascript
-const updated = await cozy.files.updateById("654321", blob, {
+const updated = await cozy.client.files.updateById("654321", blob, {
   contentType: "text/plain",
   checksum: "rL0Y20zC+Fzt72VPzMSk2A==",
   lastModifiedDate: new Date(),
@@ -376,9 +376,9 @@ const updated = await cozy.files.updateById("654321", blob, {
 ```
 
 
-### `cozy.files.updateAttributesById(id, attrs, options)`
+### `cozy.client.files.updateAttributesById(id, attrs, options)`
 
-`cozy.files.updateAttributesById(id, attrs, options)` is used to update the attributes associated to a file or directory specified by its id.
+`cozy.client.files.updateAttributesById(id, attrs, options)` is used to update the attributes associated to a file or directory specified by its id.
 
 It returns a promise for the document of the updated directory or file.
 
@@ -388,13 +388,13 @@ It returns a promise for the document of the updated directory or file.
   * `ifMatch`: the previous revision of the file (optional). The update will be rejected if the remote revision doesn't match the given one.
 
 ```javascript
-const updated = await cozy.files.updateAttributesById("12345", { tags: ["foo"] }, { ifMatch: "1-0e6d5b72" })
+const updated = await cozy.client.files.updateAttributesById("12345", { tags: ["foo"] }, { ifMatch: "1-0e6d5b72" })
 ```
 
 
-### `cozy.files.updateAttributesByPath(path, attrs, options)`
+### `cozy.client.files.updateAttributesByPath(path, attrs, options)`
 
-`cozy.files.updateAttributesByPath(path, attrs, options)` is used to update the attributes associated to a file or directory specified by its id.
+`cozy.client.files.updateAttributesByPath(path, attrs, options)` is used to update the attributes associated to a file or directory specified by its id.
 
 It returns a promise for the document of the updated directory or file.
 
@@ -404,25 +404,25 @@ It returns a promise for the document of the updated directory or file.
   * `ifMatch`: the previous revision of the file (optional). The update will be rejected if the remote revision doesn't match the given one.
 
 ```javascript
-const updated = await cozy.files.updateAttributes("/foo/bar", { executable: true }, { ifMatch: "1-0e6d5b72" })
+const updated = await cozy.client.files.updateAttributes("/foo/bar", { executable: true }, { ifMatch: "1-0e6d5b72" })
 ```
 
 
-### `cozy.files.trashById(id)`
+### `cozy.client.files.trashById(id)`
 
-`cozy.files.trashById(id)` is used to move the file or directory identified by the given id to trash.
+`cozy.client.files.trashById(id)` is used to move the file or directory identified by the given id to trash.
 
 It returns a promise for the document of the file or directory moved to trash.
 
 - `id` is a string specifying the identifier of the file or directory
 
 ```javascript
-const trashed = await cozy.files.trash("1234567")
+const trashed = await cozy.client.files.trash("1234567")
 ```
 
-## `cozy.files.destroyById(id)`
+## `cozy.client.files.destroyById(id)`
 
-`cozy.files.destroyById(id)` is used to shred (destroy definitively) a file or directory identified by the given id.
+`cozy.client.files.destroyById(id)` is used to shred (destroy definitively) a file or directory identified by the given id.
 
 The file must be in the trash folder first.
 
@@ -431,51 +431,51 @@ It returns a promise for completion
 - `id` is a string specifying the identifier of the file or directory
 
 ```javascript
-const trashed = await cozy.files.trash("1234567")
-await cozy.files.destroyById("1234567")
+const trashed = await cozy.client.files.trash("1234567")
+await cozy.client.files.destroyById("1234567")
 ```
 
-## `cozy.files.restoreById(id)`
+## `cozy.client.files.restoreById(id)`
 
-`cozy.files.restoreById(id)` is used to restore a file or directory identified by the given id. The file must be in the trash folder.
+`cozy.client.files.restoreById(id)` is used to restore a file or directory identified by the given id. The file must be in the trash folder.
 
 It returns a promise for the restored doc. (with updated parent)
 
 - `id` is a string specifying the identifier of the file or directory
 
 ```javascript
-const trashed = await cozy.files.trash("1234567")
-const restored = await cozy.files.restore("1234567")
+const trashed = await cozy.client.files.trash("1234567")
+const restored = await cozy.client.files.restore("1234567")
 ```
 
-## `cozy.files.listTrash()`
+## `cozy.client.files.listTrash()`
 
-`cozy.files.listTrash()` returns a promise for the list of all files in the trash.
+`cozy.client.files.listTrash()` returns a promise for the list of all files in the trash.
 
 ```javascript
-const trashedFilesAndFolders = await cozy.files.listTrash()
+const trashedFilesAndFolders = await cozy.client.files.listTrash()
 ```
 
 
-## `cozy.files.clearTrash()`
+## `cozy.client.files.clearTrash()`
 
-`cozy.files.clearTrash()` destroys definitively all trash content.
+`cozy.client.files.clearTrash()` destroys definitively all trash content.
 
 ```javascript
-await cozy.files.clearTrash()
+await cozy.client.files.clearTrash()
 ```
 
 
-### `cozy.files.downloadById(id)`
+### `cozy.client.files.downloadById(id)`
 
-`cozy.files.downloadById(id)` is used to download a file identified by the given id. The file is downloaded through the browser fetch method, use this if you plan to use the file in javascript after.
+`cozy.client.files.downloadById(id)` is used to download a file identified by the given id. The file is downloaded through the browser fetch method, use this if you plan to use the file in javascript after.
 
 It returns a promise of a fetch `Response` object. This response object can be used to extract the information in the wanted form.
 
 - `id` is a string specifying the identifier of the file
 
 ```javascript
-const response = await cozy.files.downloadById("1234567")
+const response = await cozy.client.files.downloadById("1234567")
 const blob = await response.blob()
 const text = await response.text()
 const buff = await response.arrayBuffer()
@@ -483,32 +483,32 @@ response.pipe(fs.createWriteStream('/some/file'))
 ```
 
 
-### `cozy.files.downloadByPath(path)`
+### `cozy.client.files.downloadByPath(path)`
 
-`cozy.files.downloadByPath(path)` is used to download a file identified by the given path. The file is downloaded through the browser fetch method, use this if you plan to use the file in javascript after.
+`cozy.client.files.downloadByPath(path)` is used to download a file identified by the given path. The file is downloaded through the browser fetch method, use this if you plan to use the file in javascript after.
 
 It returns a promise of a fetch `Response` object. This response object can be used to extract the information in the wanted form.
 
 - `path` is a string specifying the path of the file
 
 ```javascript
-const response = await cozy.files.downloadByPath("/foo/hello.txt")
+const response = await cozy.client.files.downloadByPath("/foo/hello.txt")
 const blob = await response.blob()
 const text = await response.text()
 const buff = await response.arrayBuffer()
 response.pipe(fs.createWriteStream('/some/file'))
 ```
 
-### `cozy.files.getDowloadLink(path)`
+### `cozy.client.files.getDowloadLink(path)`
 
-`cozy.files.getDowloadLink(path)` is used to get a download link for the file  identified by the given path.
+`cozy.client.files.getDowloadLink(path)` is used to get a download link for the file  identified by the given path.
 
 It returns a promise for the download link.
 Download link are only valid for a short while (default 1 hour)
 You can use this link to start a browser download like this:
 
 ```javascript
-const href = await cozy.files.getDowloadLink("/foo/hello.txt")
+const href = await cozy.client.files.getDowloadLink("/foo/hello.txt")
 const link = document.createElement('a')
 link.href = href
 link.download = fileName
@@ -518,22 +518,22 @@ document.body.appendChild(link) && link.click()
 - `path` is a string specifying the path of the file
 
 
-### `cozy.files.getArchiveLink(paths, name)`
+### `cozy.client.files.getArchiveLink(paths, name)`
 
-`cozy.files.getArchiveLink(paths, name)` is used to get a download link for a zip file containing all the files identified by the given paths.
+`cozy.client.files.getArchiveLink(paths, name)` is used to get a download link for a zip file containing all the files identified by the given paths.
 
 It returns a promise for the download link.
 Download link are only valid for a short while (default 1 hour)
 You can use this link to start a browser download (see code in getDowloadLink)
 
 ```javascript
-const href = await cozy.files.getArchiveLink([
+const href = await cozy.client.files.getArchiveLink([
   "/foo/hello.txt",
   "/bar/test.txt"
 ])
 // href === "/files/archive/b1c127c25d99f0b37ac2c2a907f36069/files.zip"
 
-const href = await cozy.files.getArchiveLink(["/foo/hello.txt"], "secretproject")
+const href = await cozy.client.files.getArchiveLink(["/foo/hello.txt"], "secretproject")
 // href === "/files/archive/bc2a901c127c25d99f0b37a36069c27f/secretproject.zip"
 ```
 
@@ -541,15 +541,15 @@ const href = await cozy.files.getArchiveLink(["/foo/hello.txt"], "secretproject"
 - `name` is the optional name for the generated archive file (default "files").
 
 
-### `cozy.addReferencedFiles(doc, fileIds)`
+### `cozy.client.addReferencedFiles(doc, fileIds)`
 
-`cozy.addReferencedFiles(doc, fileIds)` binds the files to the document.
+`cozy.client.addReferencedFiles(doc, fileIds)` binds the files to the document.
 (see cozy-stack [documentation](https://github.com/cozy/cozy-stack/blob/master/docs/references-docs-in-vfs.md) for more details)
 
 
-### `cozy.listReferencedFiles(doc)`
+### `cozy.client.listReferencedFiles(doc)`
 
-`cozy.listReferencedFiles(doc)` list the files bound to the document.
+`cozy.client.listReferencedFiles(doc)` list the files bound to the document.
 (see cozy-stack [documentation](https://github.com/cozy/cozy-stack/blob/master/docs/references-docs-in-vfs.md) for more details).
 
 It returns a promise for a list of filesIds. Files must then be fetched separately.
@@ -558,130 +558,130 @@ It returns a promise for a list of filesIds. Files must then be fetched separate
 
 ## Settings
 
-### `cozy.settings.diskUsage()`
+### `cozy.client.settings.diskUsage()`
 
-`cozy.settings.diskUsage` is used to known informations about the total used space on the cozy disk.
+`cozy.client.settings.diskUsage` is used to known informations about the total used space on the cozy disk.
 
 It returns a promise of the document of the disk-usage of id `io.cozy.settings.disk-usage`, with attributes containing a `used` field a string of how many *bytes* are used on the disk.
 
 The `used` field is a string since the underlying data is an `int64` which may not be properly represented in javascript.
 
 ```javascript
-const usage = await cozy.settings.diskUsage()
+const usage = await cozy.client.settings.diskUsage()
 console.log(usage.attributes.used)
 ```
 
-### `cozy.settings.changePassphrase(oldPassphrase, newPassphrase)`
+### `cozy.client.settings.changePassphrase(oldPassphrase, newPassphrase)`
 
-`cozy.settings.changePassphrase`is used to change the passphrase of the current user. You must supply the currently used passphrase, as well as the new one. It simply returns a promise that will resolve if the change was successful.
+`cozy.client.settings.changePassphrase`is used to change the passphrase of the current user. You must supply the currently used passphrase, as well as the new one. It simply returns a promise that will resolve if the change was successful.
 
-### `cozy.settings.getInstance()`
+### `cozy.client.settings.getInstance()`
 
-`cozy.settings.getInstance` returns a promise with informations about the current Cozy instance, such as the locale or the public name. See cozy-stack [documentation](https://github.com/cozy/cozy-stack/blob/master/docs/settings.md#response-3) for more details.
+`cozy.client.settings.getInstance` returns a promise with informations about the current Cozy instance, such as the locale or the public name. See cozy-stack [documentation](https://github.com/cozy/cozy-stack/blob/master/docs/settings.md#response-3) for more details.
 
-### `cozy.settings.updateInstance(instance)`
+### `cozy.client.settings.updateInstance(instance)`
 
-`cozy.settings.updateInstance` is used to update informations about the current instance. `instance` is an object that should be based on to the one you receive from `cozy.settings.getInstance()`. It returns a promise with the updated instance information.
+`cozy.client.settings.updateInstance` is used to update informations about the current instance. `instance` is an object that should be based on to the one you receive from `cozy.settings.getInstance()`. It returns a promise with the updated instance information.
 
-### `cozy.settings.getClients()`
+### `cozy.client.settings.getClients()`
 
-`cozy.settings.getClients` returns a promise for an array of registered clients. See the [cozy-stack documentation](https://github.com/cozy/cozy-stack/blob/master/docs/settings.md#response-5) for more details.
+`cozy.client.settings.getClients` returns a promise for an array of registered clients. See the [cozy-stack documentation](https://github.com/cozy/cozy-stack/blob/master/docs/settings.md#response-5) for more details.
 
-### `cozy.settings.deleteClientById('123')`
+### `cozy.client.settings.deleteClientById('123')`
 
-`cozy.settings.deleteClientById` revokes the specified client from the instance. This method returns a promise that simply resolves if the revokation was successful.
+`cozy.client.settings.deleteClientById` revokes the specified client from the instance. This method returns a promise that simply resolves if the revokation was successful.
 
 ## Authentication and OAuth (internal)
 
-### `cozy.auth.registerClient(clientParams)`
+### `cozy.client.auth.registerClient(clientParams)`
 
 **This method is for internal or advanced usages. Please see [OAuth document](./oauth.md) to see how to use OAuth with this library**
 
-`cozy.auth.registerClient` is used to register a new client with the specified informations.
+`cozy.client.auth.registerClient` is used to register a new client with the specified informations.
 
 It returns a promise of the newly registered Client, along with a client secret and identifier.
 
-- `clientParams` are client parameters: a non registered instance of `cozy.auth.Client`
+- `clientParams` are client parameters: a non registered instance of `cozy.client.auth.Client`
 
 ```js
-const clientParams = new cozy.auth.Client({
+const clientParams = new cozy.client.auth.Client({
   redirectURI: 'http://localhost:3000/',
   softwareID: 'mysoftware',
   clientName: 'Great mobile App'
 })
-const client = await cozy.auth.registerClient(clientParams)
+const client = await cozy.client.auth.registerClient(clientParams)
 const clientID = client.clientID
 const clientSecret = client.clientSecret
 ```
 
-### `cozy.auth.updateClient(client, resetSecret = false)`
+### `cozy.client.auth.updateClient(client, resetSecret = false)`
 
 **This method is for internal or advanced usages. Please see [OAuth document](./oauth.md) to see how to use OAuth with this library**
 
-`cozy.auth.updateClient` is used to update informations about the oauth client.
+`cozy.client.auth.updateClient` is used to update informations about the oauth client.
 
 It returns a promise for the updated Client.
 
-- `client` a registered instance of `cozy.auth.Client`
+- `client` a registered instance of `cozy.client.auth.Client`
 - `resetSecret` by setting `resetSecret` to `true`, a new Secret is generated.
 
 ```js
-const client = await cozy.auth.registerClient(clientParams)
+const client = await cozy.client.auth.registerClient(clientParams)
 
 // change the client's version
 client.softwareVersion = "v1.2.3"
-const client = await cozy.auth.updateClient(client)
+const client = await cozy.client.auth.updateClient(client)
 
 
 // change the client secret
-const client = await cozy.auth.updateClient(client, true)
+const client = await cozy.client.auth.updateClient(client, true)
 ```
 
-### `cozy.auth.unregisterClient(client)`
+### `cozy.client.auth.unregisterClient(client)`
 
 **This method is for internal or advanced usages. Please see [OAuth document](./oauth.md) to see how to use OAuth with this library**
 
-`cozy.auth.unregisterClient` is used to unregister a client.
+`cozy.client.auth.unregisterClient` is used to unregister a client.
 
 It returns a promise for completion
 
-- `client` a registered instance of `cozy.auth.Client`
+- `client` a registered instance of `cozy.client.auth.Client`
 
 ```js
-const client = await cozy.auth.registerClient(clientParams)
-await cozy.auth.unregisterClient(client)
+const client = await cozy.client.auth.registerClient(clientParams)
+await cozy.auth.client.unregisterClient(client)
 ```
 
-### `cozy.auth.getClient(client)`
+### `cozy.auth.client.getClient(client)`
 
 **This method is for internal or advanced usages. Please see [OAuth document](./oauth.md) to see how to use OAuth with this library**
 
-`cozy.auth.getClient` is used to fetch a registered client with the specified clientID and token.
+`cozy.client.auth.getClient` is used to fetch a registered client with the specified clientID and token.
 
 It returns a promise of the client returned by the server.
 
-- `client` is a registered `cozy.auth.Client`
+- `client` is a registered `cozy.client.auth.Client`
 
 ```js
-const client = await cozy.auth.getClient(new cozy.auth.Client({
+const client = await cozy.client.auth.getClient(new cozy.client.auth.Client({
   clientID: '1235'
 }))
 ```
 
 
-### `cozy.auth.getAuthCodeURL(client, scopes)`
+### `cozy.client.auth.getAuthCodeURL(client, scopes)`
 
 **This method is for internal or advanced usages. Please see [OAuth document](./oauth.md) to see how to use OAuth with this library**
 
-`cozy.auth.getAuthCodeURL` is used to generate the URL on which the user should go to give access to the application with the specified scopes.
+`cozy.client.auth.getAuthCodeURL` is used to generate the URL on which the user should go to give access to the application with the specified scopes.
 
 It returns an object with the url and a generated random state that should be stored to be matched again for the token exchange phase.
 
-- `client` is a registered `cozy.auth.Client`
+- `client` is a registered `cozy.client.auth.Client`
 - `scopes` is an array of permission strings formatted as `key:access` (like `files/images:read`)
 
 ```js
-const {url, state} = cozy.auth.getAuthCodeURL(client, ['files/images:read'])
+const {url, state} = cozy.client.auth.getAuthCodeURL(client, ['files/images:read'])
 
 // save state and redirect to url
 localStorage.setItem("oauthstate", state)
@@ -689,45 +689,45 @@ window.location.replace(url)
 ```
 
 
-### `cozy.auth.getAccessToken(client, state, pageURL)`
+### `cozy.client.auth.getAccessToken(client, state, pageURL)`
 
 **This method is for internal or advanced usages. Please see [OAuth document](./oauth.md) to see how to use OAuth with this library**
 
-`cozy.auth.getAccessToken` is used from the page on which the user should have redirected after authorizing the application.
+`cozy.client.auth.getAccessToken` is used from the page on which the user should have redirected after authorizing the application.
 
-It returns a promise of an `cozy.auth.AccessToken`. The method verifies that the specified state and the extracted one match. It then ask the server for a new access token and returns it.
+It returns a promise of an `cozy.client.auth.AccessToken`. The method verifies that the specified state and the extracted one match. It then ask the server for a new access token and returns it.
 
-- `client` is a registered `cozy.auth.Client`
+- `client` is a registered `cozy.client.auth.Client`
 - `state` is the previously stored state that is matched against to prevent CSRF attacks
 - `pageURL` is the url of the current page from the which a code and state will be extracted. If empty, `window.location.href` is used
 
 ```js
-const client = cozy.auth.getClient(/* ... */)
+const client = cozy.client.auth.getClient(/* ... */)
 const state = localStorage.getItem("oauthstate")
 const pageURL = window.location.href
-const token = cozy.auth.getAccessToken(client, state, pageURL)
+const token = cozy.client.auth.getAccessToken(client, state, pageURL)
 ```
 
 
-### `cozy.auth.refreshToken`
+### `cozy.client.auth.refreshToken`
 
 **This method is for internal or advanced usages. Please see [OAuth document](./oauth.md) to see how to use OAuth with this library**
 
-`refreshToken` is used to refresh a token that is expired or no more valid.
+`cozy.client.auth.refreshToken` is used to refresh a token that is expired or no more valid.
 
-- `client` is a registered `cozy.auth.Client`
-- `token` is a valid `cozy.auth.AccessToken`
+- `client` is a registered `cozy.client.auth.Client`
+- `token` is a valid `cozy.client.auth.AccessToken`
 
 ```js
-const newtoken = cozy.auth.refreshToken(client, oldtoken)
+const newtoken = cozy.client.auth.refreshToken(client, oldtoken)
 ```
 
 
-### `cozy.auth.Client`
+### `cozy.client.auth.Client`
 
 **This class is for internal or advanced usages. Please see [OAuth document](./oauth.md) to see how to use OAuth with this library**
 
-`cozy.auth.Client` is a class representing an OAuth client. It can be registered, in which case it is known by the server and has a `clientID` and `clientSecret`.
+`cozy.client.auth.Client` is a class representing an OAuth client. It can be registered, in which case it is known by the server and has a `clientID` and `clientSecret`.
 
 ```
 type Client {
@@ -755,11 +755,11 @@ new Client(url, options)
 ```
 
 
-### `cozy.auth.AccessToken`
+### `cozy.client.auth.AccessToken`
 
 **This class is for internal or advanced usages. Please see [OAuth document](./oauth.md) to see how to use OAuth with this library**
 
-`cozy.auth.AccessToken` is a class representing an OAuth access token.
+`cozy.client.auth.AccessToken` is a class representing an OAuth access token.
 
 ```
 type Token {


### PR DESCRIPTION
As promised, this PR updates the whole documentation to reflect the new namespace under which `cozy-client-js` is published 😅