### PR TITLE
[feat] Add helper to get file path

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -541,6 +541,12 @@ const href = await cozy.client.files.getArchiveLink(["/foo/hello.txt"], "secretp
 - `name` is the optional name for the generated archive file (default "files").
 
 
+### `cozy.client.getFilePath(file, folder)`
+
+`cozy.client.getFilePath(file, folder)` is a helper that generate the file path from root directory. It may be used to specify the path parameter for functions like
+`cozy.client.files.downloadByPath`, `cozy.client.files.getDownloadLink` or `cozy.client.files.getArchiveLink`.
+
+
 ### `cozy.client.addReferencedFiles(doc, fileIds)`
 
 `cozy.client.addReferencedFiles(doc, fileIds)` binds the files to the document.

--- a/src/files.js
+++ b/src/files.js
@@ -184,6 +184,18 @@ export function getDowloadLink (cozy, path) {
     .then(extractResponseLinkRelated)
 }
 
+export function getFilePath (cozy, file = {}, folder) {
+  if (!folder || !folder.attributes) {
+    throw Error('Folder should be valid with an attributes.path property')
+  }
+
+  const folderPath = folder.attributes.path.endsWith('/')
+    ? folder.attributes.path
+      : `${folder.attributes.path}/`
+
+  return `${folderPath}${file.name}`
+}
+
 export function getArchiveLink (cozy, paths, name = 'files') {
   const archive = {
     type: 'io.cozy.archives',

--- a/src/index.js
+++ b/src/index.js
@@ -67,6 +67,7 @@ const filesProto = {
   downloadByPath: files.downloadByPath,
   getDowloadLink: files.getDowloadLink,
   getArchiveLink: files.getArchiveLink,
+  getFilePath: files.getFilePath,
   listTrash: files.listTrash,
   clearTrash: files.clearTrash,
   restoreById: files.restoreById,

--- a/test/unit/files.js
+++ b/test/unit/files.js
@@ -368,4 +368,67 @@ describe('Files', function () {
       })
     })
   })
+
+  describe('Get file path', function () {
+    it('should throw error on missing folder', function () {
+      const file = {}
+      const call = () => {
+        cozy.client.files.getFilePath(file)
+      }
+      should.throws(call, 'Folder should be valid with an attributes.path property')
+    })
+
+    it('should throw error on invalid folder', function () {
+      const file = {}
+      const folder = {}
+      const call = () => {
+        cozy.client.files.getFilePath(file, folder)
+      }
+      should.throws(call, 'Folder should be valid with an attributes.path property')
+    })
+
+    it('should return file path in root', function () {
+      const file = {name: 'random.ext'}
+      const folder = {
+        attributes: {
+          path: '/'
+        }
+      }
+      const res = cozy.client.files.getFilePath(file, folder)
+      res.should.be.equal('/random.ext')
+    })
+
+    it('should return file path in root with empty path', function () {
+      const file = {name: 'random.ext'}
+      const folder = {
+        attributes: {
+          path: ''
+        }
+      }
+      const res = cozy.client.files.getFilePath(file, folder)
+      res.should.be.equal('/random.ext')
+    })
+
+    it('should return file path in folder ending with `/`', function () {
+      const file = {name: 'random.ext'}
+      const folder = {
+        attributes: {
+          path: '/test/'
+        }
+      }
+      const res = cozy.client.files.getFilePath(file, folder)
+      res.should.be.equal('/test/random.ext')
+    })
+
+    it('should return file path in folder ending with no `/``', function () {
+      const file = {name: 'random.ext'}
+      const folder = {
+        attributes: {
+          path: '/test'
+        }
+      }
+      const res = cozy.client.files.getFilePath(file, folder)
+      res.should.be.equal('/test/random.ext')
+    })
+  })
 })


### PR DESCRIPTION
To call `cozy.files.getDownloadLink`, I needed to generate path for a given file.

As this little piece of logic is already used in Files, I think we should add a little helper in cozy-client-js to facilitates further developments and mutualize code.