### PR TITLE
handling custom code on replication complete or error

### DIFF
--- a/src/offline.js
+++ b/src/offline.js
@@ -141,9 +141,11 @@ export function replicateFromCozy (cozy, doctype, options = {}) {
     getReplicationUrl(cozy, doctype)
       .then(url => setReplication(cozy, doctype,
         getDatabase(cozy, doctype).replicate.from(url, options).on('complete', (info) => {
+          options.onComplete && options.onComplete(info)
           setReplication(cozy, doctype, undefined)
           resolve(info)
         }).on('error', (err) => {
+          options.onError && options.onError(err)
           console.warn(`ReplicateFromCozy '${doctype}' Error:`)
           console.warn(err)
           setReplication(cozy, doctype, undefined)


### PR DESCRIPTION
I need to do something like this for https://github.com/cozy/cozy-files-v3/pull/138

Maybe, instead of adding an `onError` onto the replication, we could provide a way to handling an `onError` custom code within the whole cozy-client-js code base. We could set it up in the `init()` function.

You decide.