### PR TITLE
feat: enhance offline behavior

### DIFF
--- a/src/files.js
+++ b/src/files.js
@@ -150,9 +150,7 @@ export function statById (cozy, id, offline = true) {
       db.get(id),
       db.find({selector: {'dir_id': id}})
     ]).then(([doc, children]) => {
-      children = children.docs.map(doc => {
-        return addIsDir(toJsonApi(cozy, doc))
-      })
+      children = children.docs.map(doc => addIsDir(toJsonApi(cozy, doc)))
       return addIsDir(toJsonApi(cozy, doc, children))
     })
   }

--- a/test/integration/offline.js
+++ b/test/integration/offline.js
@@ -56,19 +56,6 @@ describe('offline', function () {
       .should.be.rejectedWith({ message: 'You can\'t use `live` option with Cozy couchdb.' })
   })
 
-  it('can\'t replicate without adding the correct doctype.', async function () {
-    await cozy.client.offline.createDatabase(DOCTYPE, {adapter: 'memory'})
-    const wrongDoctype = 'another.doctype'
-    return cozy.client.offline.replicateFromCozy(wrongDoctype)
-      .should.be.rejectedWith({ message: `You should add this doctype: ${wrongDoctype} to offline.` })
-  })
-
-  it('can\'t replicate without creating the database in offline.', async function () {
-    const someDoctype = 'some.doctype'
-    return cozy.client.offline.replicateFromCozy(someDoctype)
-      .should.be.rejectedWith({ message: `You should add this doctype: ${someDoctype} to offline.` })
-  })
-
   it('can replicate created object in local database', async function () {
     // create a database
     const db = await cozy.client.offline.createDatabase(DOCTYPE, { adapter: 'memory' })


### PR DESCRIPTION
onError and onComplete are both being called too early.

And I don't believe it is a good idea to raise a *no database error* if we start a replication.
I do believe that when we launch a replication, if there is no local database, we should create one.

It is related to https://github.com/cozy/cozy-files-v3/pull/157