### PR TITLE
feat: refresh token for offline replication

### DIFF
--- a/src/fetch.js
+++ b/src/fetch.js
@@ -32,7 +32,7 @@ function cozyFetchWithAuth (cozy, fullpath, options, credentials) {
     cozy.isV2(),
     fetch(fullpath, options)
   ]).then(([isV2, res]) => {
-    if (res.status !== 401 || isV2 || !credentials) {
+    if ((res.status !== 401 && res.status !== 400) || isV2 || !credentials) {
       return res
     }
     // we try to refresh the token only for OAuth, ie, the client defined


### PR DESCRIPTION
Here is the workflow when repeated replication are engaged:

1. open the application
1. call `statById` to list the default folder's content
(via `openFolder`)
1. `startRepeatedReplication` (via `registerDevice`)

Then the token becomes obsolete and need to be refreshed.

If a request is sent to the server, it uses this code to refresh the
token. But it get a response with code `400`.

See https://github.com/cozy/cozy-client-js/blob/master/src/fetch.js#L35

On the other hand, the repeated replication continues to work until
we refresh the page, I can't understand why.

See https://github.com/cozy/cozy-client-js/blob/master/src/offline.js#L115