### PR TITLE
fix: mime-type was not detected in cordova

### DIFF
--- a/src/files.js
+++ b/src/files.js
@@ -35,7 +35,7 @@ function doUpload (cozy, data, method, path, options) {
         lastModifiedDate = data.lastModifiedDate
       }
     } else if (isBlob) {
-      contentType = contentTypeOctetStream
+      contentType = data.type || contentTypeOctetStream
     } else if (isStream) {
       contentType = contentTypeOctetStream
     } else if (typeof data === 'string') {


### PR DESCRIPTION
When a cordova application uses the cordova-plugin-file plugin, `window.File` is overwritten by another object, see https://github.com/apache/cordova-plugin-file/blob/master/www/File.js#L31.

So the line `data instanceof File` is `false` then the code enters the `isBlob` conditionnal scope that is why we change this line to get `data.type` if it exists or `contentTypeOctetStream` otherwise.