### PR TITLE
chore: watch mode build :construction_worker:

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build:web:min": "NODE_ENV=production NODE_TARGET=web webpack",
     "build:node": "NODE_ENV=production NODE_TARGET=node webpack",
     "build": "npm-run-all --parallel 'build:*' 'build:*:*'",
-    "watch": "NODE_ENV=production NODE_TARGET=web webpack --watch",
+    "watch": "NODE_ENV=development NODE_TARGET=web webpack --watch",
     "lint": "standard './src/**/*.js' './test/**/*.js' webpack.config.js",
     "test": "npm-run-all 'test:*'",
     "test:unit": "NODE_ENV=test NODE_TARGET=node mocha-webpack 'test/unit/**.js'",


### PR DESCRIPTION
I suggest `yarn watch` build a non-minified
version of the lib as the `yarn watch` on
others projects use the non-minified version.

Here is my workflow:

```
z cozy-client-js
yarn link
yarn watch &
z cozy-files-v3
yarn link cozy-client-js
yarn watch:mobile:standalone &
```

*With z to jump to a folder.*