### PR TITLE
feat: Add intents

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "pouchdb-adapter-memory": "6.1.1",
     "pouchdb-find": "0.10.4",
     "should": "11.1.1",
+    "sinon": "^2.1.0",
     "source-map-support": "0.4.5",
     "standard": "8.6.0",
     "standard-loader": "5.0.0",

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,7 @@ import * as auth from './auth_v3'
 import * as data from './data'
 import * as mango from './mango'
 import * as files from './files'
+import * as intents from './intents'
 import * as offline from './offline'
 import * as settings from './settings'
 import * as relations from './relations'
@@ -77,6 +78,11 @@ const filesProto = {
   destroyById: files.destroyById
 }
 
+const intentsProto = {
+  start: intents.start,
+  resovle: intents.resolve
+}
+
 const offlineProto = {
   init: offline.init,
   getDoctypes: offline.getDoctypes,
@@ -111,6 +117,7 @@ class Client {
   constructor (options) {
     this.data = {}
     this.files = {}
+    this.intents = {}
     this.offline = {}
     this.settings = {}
     this.auth = {
@@ -163,6 +170,7 @@ class Client {
     addToProto(this, this.data, dataProto, disablePromises)
     addToProto(this, this.auth, authProto, disablePromises)
     addToProto(this, this.files, filesProto, disablePromises)
+    addToProto(this, this.intents, intentsProto, disablePromises)
     addToProto(this, this.offline, offlineProto, disablePromises)
     addToProto(this, this.settings, settingsProto, disablePromises)
 

--- a/src/intents.js
+++ b/src/intents.js
@@ -1,3 +1,4 @@
+/* global URL */
 const intentClass = 'coz-intent'
 
 function getUrl (intent, temporaryMockedIntentUrl) {
@@ -17,7 +18,7 @@ function injectService (url, element, intent) {
   element.appendChild(iframe)
 
   // Keeps only http://domain:port/
-  const serviceOrigin = url.split('/', 3).join('/')
+  const serviceOrigin = new URL(url).origin
 
   return new Promise((resolve, reject) => {
     let handshaken = false

--- a/src/intents.js
+++ b/src/intents.js
@@ -1,0 +1,61 @@
+const intentClass = 'coz-intent'
+
+function getUrl (intent, temporaryMockedIntentUrl) {
+  return Promise.resolve(temporaryMockedIntentUrl)
+}
+
+function injectService (url, element, intent) {
+  const document = element.ownerDocument
+  if (!document) throw new Error('Cannot retrieve document object from given element')
+
+  const window = document.defaultView
+  if (!window) throw new Error('Cannot retrieve window object from document')
+
+  const iframe = document.createElement('iframe')
+  iframe.setAttribute('src', url)
+  iframe.classList.add(intentClass)
+  element.appendChild(iframe)
+
+  // Keeps only http://domain:port/
+  const serviceOrigin = url.split('/', 3).join('/')
+
+  return new Promise((resolve, reject) => {
+    let handshaken = false
+    const messageHandler = (event) => {
+      if (event.origin !== serviceOrigin) return
+
+      if (event.data === 'intent:ready') {
+        handshaken = true
+        return event.source.postMessage(intent.data, event.origin)
+      }
+
+      window.removeEventListener('message', messageHandler)
+
+      if (event.data === 'intent:error') {
+        return reject(new Error('Intent error'))
+      }
+
+      return handshaken
+        ? iframe.parentNode.removeChild(iframe) && resolve(event.data)
+        : reject(new Error('Unexpected handshake message from intent service'))
+    }
+
+    window.addEventListener('message', messageHandler)
+  })
+}
+
+export function start (client, intent, element, temporaryMockedIntentUrl) {
+  ['action', 'type'].forEach((property) => {
+    if (!intent[property]) {
+      throw new Error(`Misformed intent, "${property}" property must be provided`)
+    }
+  })
+
+  // To replace with a call to client
+  return getUrl(intent, temporaryMockedIntentUrl)
+    .then(url => injectService(url, element, intent))
+}
+
+export function resolve () {
+  // TODO
+}

--- a/test/unit/intents.js
+++ b/test/unit/intents.js
@@ -1,0 +1,155 @@
+/* eslint-env mocha */
+
+// eslint-disable-next-line no-unused-vars
+import should from 'should'
+import sinon from 'sinon'
+import {Client} from '../../src'
+
+function mockElement () {
+  const windowMock = {
+    postMessage: sinon.spy(),
+    addEventListener: sinon.stub(),
+    removeEventListener: sinon.spy()
+  }
+  const iframeMock = {
+    setAttribute: sinon.spy(),
+    parentNode: {
+      removeChild: sinon.spy()
+    },
+    classList: {
+      add: sinon.spy()
+    }
+  }
+  const documentMock = {
+    defaultView: windowMock,
+    createElement: sinon.stub().returns(iframeMock)
+  }
+  return {
+    ownerDocument: documentMock,
+    appendChild: sinon.spy(),
+    iframeMock: iframeMock,
+    documentMock: documentMock,
+    windowMock: windowMock
+  }
+}
+
+describe('Intents', function () {
+  const cozy = {}
+  const intent = {
+    action: 'PICK',
+    type: 'io.cozy.contact',
+    data: {
+      firstname: 'claude',
+      lastname: 'causi'
+    }
+  }
+  const serviceUrl = 'test.cozy.local'
+
+  beforeEach(() => {
+    cozy.client = new Client({
+      cozyURL: 'http://my.cozy.io///',
+      token: 'apptoken'
+    })
+  })
+
+  describe('Start', function () {
+    it('should throw error for malformed intents', function () {
+      const worstIntentEver = {}
+      const intentWithoutAction = {type: 'io.cozy.files'}
+      const intentWithoutType = {action: 'PICK'}
+
+      should.throws(
+        () => cozy.client.intents.start(worstIntentEver, mockElement()),
+        /Misformed intent, "action" property must be provided/
+      )
+
+      should.throws(
+        () => cozy.client.intents.start(intentWithoutAction, mockElement()),
+        /Misformed intent, "action" property must be provided/
+      )
+
+      should.throws(
+        () => cozy.client.intents.start(intentWithoutType, mockElement()),
+        /Misformed intent, "type" property must be provided/
+      )
+    })
+
+    it('should inject iframe', function () {
+      const element = mockElement()
+      const {documentMock, iframeMock} = element
+      cozy.client.intents.start(intent, element, serviceUrl)
+
+      should(documentMock.createElement.withArgs('iframe').calledOnce).be.true
+      should(iframeMock.setAttribute.withArgs('src', serviceUrl).calledOnce).be.true
+      should(iframeMock.classList.add.withArgs('coz-intent').calledOnce).be.true
+      should(element.appendChild.withArgs(iframeMock).calledOnce).be.true
+    })
+
+    it('shoud manage handshake', async function () {
+      const element = mockElement()
+      const {windowMock} = element
+
+      windowMock.addEventListener
+        .withArgs('message')
+        .onFirstCall()
+        .callsArgWith(1, 'intent:ready', serviceUrl)
+
+      cozy.client.intents.start(intent, element, serviceUrl)
+
+      should(windowMock.addEventListener.withArgs('message').calledOnce).be.true
+      should(windowMock.removeEventListener.neverCalledWith('message')).be.true
+      should(windowMock.postMessage.calledWithMatch(intent.data, serviceUrl)).be.true
+    })
+
+    it('should manage handshake fail', async function () {
+      const element = mockElement()
+      const {windowMock} = element
+
+      windowMock.addEventListener
+        .withArgs('message')
+        .onFirstCall()
+        .callsArgWith(1, 'totally unexpected message', serviceUrl)
+
+      cozy.client.intents.start(intent, element, serviceUrl)
+        .should.be.rejectedWith(/Unexpected handshake message from intent service/)
+
+      should(windowMock.removeEventListener.withArgs('message').calledOnce).be.true
+    })
+
+    it('should handle intent error', async function () {
+      const element = mockElement()
+      const {windowMock} = element
+
+      windowMock.addEventListener
+        .withArgs('message')
+        .onFirstCall()
+        .callsArgWith(1, 'intent:error', serviceUrl)
+
+      cozy.client.intents.start(intent, element, serviceUrl)
+        .should.be.rejectedWith(/Intent error/)
+
+      should(windowMock.removeEventListener.withArgs('message').calledOnce).be.true
+    })
+
+    it('should handle intent success', async function () {
+      const element = mockElement()
+      const {windowMock, iframeMock} = element
+      const intentResult = {
+        lastname: 'Causi',
+        firstname: 'Claude'
+      }
+
+      windowMock.addEventListener
+        .withArgs('message')
+        .onFirstCall()
+        .callsArgWith(1, 'intent:ready', serviceUrl)
+        .callsArgWith(1, intentResult, serviceUrl)
+
+      cozy.client.intents.start(intent, element, serviceUrl)
+        .should.be.fulfilledWith(intentResult)
+
+      should(iframeMock.parentNode.removeChild.withArgs(iframeMock).calledOnce).be.true
+      should(windowMock.removeEventListener.withArgs('message').calledOnce).be.true
+    })
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -1456,6 +1456,10 @@ diff@1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-1.4.0.tgz#7f28d2eb9ee7b15a97efd89ce63dcfdaa3ccbabf"
 
+diff@^3.1.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-3.2.0.tgz#c9ce393a4b7cbd0b058a725c93df299027868ff9"
+
 doctrine@^1.2.1, doctrine@^1.2.2:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-1.5.0.tgz#379dce730f6166f76cefa4e6707a159b02c5a6fa"
@@ -2101,6 +2105,12 @@ form-data@~2.1.1:
     asynckit "^0.4.0"
     combined-stream "^1.0.5"
     mime-types "^2.1.12"
+
+formatio@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/formatio/-/formatio-1.2.0.tgz#f3b2167d9068c4698a8d51f4f760a39a54d818eb"
+  dependencies:
+    samsam "1.x"
 
 forwarded@~0.1.0:
   version "0.1.0"
@@ -3126,7 +3136,7 @@ lodash@3.8.0:
   version "3.8.0"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.8.0.tgz#376eb98bdcd9382a9365c33c4cb8250de1325b91"
 
-lodash@4.13.1, lodash@^4.0.0, lodash@^4.3.0:
+lodash@4.13.1, lodash@^4.0.0, lodash@^4.3.0, lodash@^4.5.0, lodash@^4.6.1:
   version "4.13.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.13.1.tgz#83e4b10913f48496d4d16fec4a560af2ee744b68"
 
@@ -3138,13 +3148,17 @@ lodash@4.6.1, lodash@^4.2.0:
   version "4.6.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.6.1.tgz#df00c1164ad236b183cfc3887a5e8d38cc63cbbc"
 
-lodash@^4.14.0, lodash@^4.5.0, lodash@^4.6.1:
+lodash@^4.14.0:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
 log-skeleton@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/log-skeleton/-/log-skeleton-1.1.0.tgz#c63709d34d7ee1f827e34072cdd51bf20e0c7291"
+
+lolex@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/lolex/-/lolex-1.6.0.tgz#3a9a0283452a47d7439e72731b9e07d7386e49f6"
 
 longest@^1.0.1:
   version "1.0.1"
@@ -3394,6 +3408,10 @@ nan@^2.3.0, nan@^2.3.3, nan@~2.4.0:
 nan@~2.3.0:
   version "2.3.5"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.3.5.tgz#822a0dc266290ce4cd3a12282ca3e7e364668a08"
+
+native-promise-only@^0.8.1:
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/native-promise-only/-/native-promise-only-0.8.1.tgz#20a318c30cb45f71fe7adfbf7b21c99c1472ef11"
 
 natural-compare@^1.4.0:
   version "1.4.0"
@@ -3812,6 +3830,12 @@ path-parse@^1.0.5:
 path-to-regexp@0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.3.tgz#21b9ab82274279de25b156ea08fd12ca51b8aecb"
+
+path-to-regexp@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.7.0.tgz#59fde0f435badacba103a84e9d3bc64e96b9937d"
+  dependencies:
+    isarray "0.0.1"
 
 path-type@^1.0.0:
   version "1.1.0"
@@ -4563,6 +4587,10 @@ safe-json-stringify@~1:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/safe-json-stringify/-/safe-json-stringify-1.0.4.tgz#81a098f447e4bbc3ff3312a243521bc060ef5911"
 
+samsam@1.x, samsam@^1.1.3:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/samsam/-/samsam-1.2.1.tgz#edd39093a3184370cb859243b2bdf255e7d8ea67"
+
 scope-eval@0.0.3:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/scope-eval/-/scope-eval-0.0.3.tgz#166f2ccd1f3754429dec511805501f9d6923b5ec"
@@ -4819,6 +4847,19 @@ simple-get@^1.4.2:
 simple-mime@~0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/simple-mime/-/simple-mime-0.1.0.tgz#95f517c4f466d7cff561a71fc9dab2596ea9ef2e"
+
+sinon@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/sinon/-/sinon-2.1.0.tgz#e057a9d2bf1b32f5d6dd62628ca9ee3961b0cafb"
+  dependencies:
+    diff "^3.1.0"
+    formatio "1.2.0"
+    lolex "^1.6.0"
+    native-promise-only "^0.8.1"
+    path-to-regexp "^1.7.0"
+    samsam "^1.1.3"
+    text-encoding "0.6.4"
+    type-detect "^4.0.0"
 
 slash@^1.0.0:
   version "1.0.0"
@@ -5186,6 +5227,10 @@ term-vector@0.0.15:
     lodash "3.5.0"
     stopword "0.0.4"
 
+text-encoding@0.6.4:
+  version "0.6.4"
+  resolved "https://registry.yarnpkg.com/text-encoding/-/text-encoding-0.6.4.tgz#e399a982257a276dae428bb92845cb71bdc26d19"
+
 text-table@^0.2.0, text-table@~0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
@@ -5280,6 +5325,10 @@ type-detect@0.1.1:
 type-detect@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-1.0.0.tgz#762217cc06db258ec48908a1298e8b95121e8ea2"
+
+type-detect@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.0.tgz#62053883542a321f2f7b25746dc696478b18ff6b"
 
 type-is@1.2.0:
   version "1.2.0"


### PR DESCRIPTION
This PR adds `cozy.client.intents.start()` methods wich allow to inject an iframe from another service for a given intent.

`cozy.client.intents.resolve()`, used in services, will be implemented later.

At this time, it is almost a POC. As we don't have a service to get the proper url from a given intent, the `cozy.client.intents.start()` method takes a temporary third argument, which is the mocked url that we want to use for the intent.

It has been discussed with @y-lohse where we should implement the intents logic.

First, it as been proposed that they may be served by the cozy-bar. But as intents are needed both in onboarding and in intent service pages, which do not contain a cozy-bar, we decided to implement them in cozy-client-js. Our fear was that DOM interaction would have been too much for a lib dedicated to call the stack. Eventually, it appeared that the main interaction was injecting an iframe and use the `window.postMessage` API. As this is a small bunch of code, I feel that it fit well in `cozy-client-js`.