### PR TITLE
chore: removes PouchDB dependency

### DIFF
--- a/docs/offline.md
+++ b/docs/offline.md
@@ -1,0 +1,27 @@
+This document describes in more details how to use this library in offline mode.
+
+All applications do not require offline mode, and offline mode needs two large dependencies : `pouchdb` and `pouchdb-find`.
+As those two dependencies are expensive in size, we decided to not provide them by default, since v0.2.0.
+
+So if an app needs to use offline mode, it will need to add those dependencies by itself. It means that developers just need to do:
+
+```bash
+yarn add pouchdb
+yarn add pouchdb-find
+```
+
+Then they will have to import `pouchdb` and `pouchdbfind` globally, as they are not imported in codebase anymore. This means adding the following configuration in all concerned webpack target files (for example `webpack.target.mobile.js`) :
+
+```js
+module.exports = {
+  ...
+  plugins: [
+    new webpack.ProvidePlugin({
+      'PouchDB': 'pouchdb',
+      'pouchdbFind': 'pouchdb-find'
+    })
+  ]
+}
+```
+
+This same configuration has to be added in file `wepback.config.prod.js`, to make the build possible.

--- a/docs/offline.md
+++ b/docs/offline.md
@@ -1,13 +1,13 @@
 This document describes in more details how to use this library in offline mode.
 
-All applications do not require offline mode, and offline mode needs two large dependencies : `pouchdb` and `pouchdb-find`.
-As those two dependencies are expensive in size, we decided to not provide them by default, since v0.2.0.
+All applications do not require offline mode, and offline mode needs two dependencies : `pouchdb` and `pouchdb-find`.
+As both are very large, we decide not to provide them by default, since v0.2.0.
 
-So if an app needs to use offline mode, it will need to add those dependencies by itself. It means that developers just need to do:
+So if your app needs to use offline mode, you have to add those dependencies by yourself. It means you just need to do:
 
 ```bash
-yarn add pouchdb
-yarn add pouchdb-find
+$/your-app> yarn add pouchdb
+$/your-app> yarn add pouchdb-find
 ```
 
 Then they will have to import `pouchdb` and `pouchdbfind` globally, as they are not imported in codebase anymore. This means adding the following configuration in all concerned webpack target files (for example `webpack.target.mobile.js`) :

--- a/src/offline.js
+++ b/src/offline.js
@@ -1,5 +1,4 @@
-import PouchDB from 'pouchdb'
-import pouchdbFind from 'pouchdb-find'
+/* global PouchDB, pouchdbFind */
 import {DOCTYPE_FILES} from './doctypes'
 import {refreshToken} from './auth_v3'
 
@@ -16,6 +15,8 @@ let pluginLoaded = false
 */
 
 export function init (cozy, { options = {}, doctypes = [] }) {
+  if (typeof PouchDB === 'undefined') throw new Error('Missing pouchdb dependency for offline mode. Please run "yarn add pouchdb" and provide PouchDB as a webpack plugin.')
+  if (typeof pouchdbFind === 'undefined') throw new Error('Missing pouchdb-find dependency for offline mode. Please run "yarn add pouchdb-find" and provide pouchdbFind as webpack plugin.')
   for (let doctype of doctypes) {
     createDatabase(cozy, doctype, options)
   }

--- a/test/integration/offline.js
+++ b/test/integration/offline.js
@@ -5,8 +5,14 @@ import should from 'should'
 import 'isomorphic-fetch'
 import { Client } from '../../src'
 import PouchDB from 'pouchdb'
+import pouchdbFind from 'pouchdb-find'
 import { sleep } from '../../src/utils'
 PouchDB.plugin(require('pouchdb-adapter-memory'))
+
+// PouchDB should not be a mandatory dependency as it is only used in mobile
+// environment, so we declare it in global scope here.
+global.PouchDB = PouchDB
+global.pouchdbFind = pouchdbFind
 
 const COZY_STACK_URL = process.env && process.env.COZY_STACK_URL || ''
 const COZY_STACK_VERSION = process.env && process.env.COZY_STACK_VERSION

--- a/test/unit/offline.js
+++ b/test/unit/offline.js
@@ -4,7 +4,13 @@
 import should from 'should'
 import {Client} from '../../src'
 import PouchDB from 'pouchdb'
+import pouchdbFind from 'pouchdb-find'
 PouchDB.plugin(require('pouchdb-adapter-memory'))
+
+// PouchDB should not be a mandatory dependency as it is only used in mobile
+// environment, so we declare it in global scope here.
+global.PouchDB = PouchDB
+global.pouchdbFind = pouchdbFind
 
 describe('offline', () => {
   const fileDoctype = 'io.cozy.files'


### PR DESCRIPTION
Should fix the issue discussed in https://github.com/cozy/cozy-client-js/issues/88.

Instead of editing [`webpack.target.mobile.js`](https://github.com/cozy/cozy-files-v3/blob/master/config/webpack.target.mobile.js) like @m4dz proposal, I suggest to use `webpack.ProvidePlugin()` instead (Actually using  `imports-loader` did not work for me) :

```js
module.exports = {
  ...
  plugins: [
    new webpack.ProvidePlugin({
       'PouchDB': 'pouchdb',
       'pouchdbFind': 'pouchdb-find'
    })
  ]
}
```
