### PR TITLE
feat: Add cozyVersion parameter to remove '/status/' request (offline) :bath:

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -119,11 +119,13 @@ It does not return a value.
   * `cozyURL`: absolute url of the cozy stack
   * `disablePromises`: boolean to make function that returns promise used with a classical "callback as last argument" (default value is *false*)
   * `oauth`: an object with the OAuth parameters, see [OAuth](./oauth.md) for details
+  * `version`: the version of Cozy (2 or 3), it's optional, by default with a request to the server it can deduce automatically the version. (To be specified for an offline mode)
 
 ```javascript
 cozy.client.init({
   cozyURL: 'http://cozy.tools:8080',
   disablePromises: false,
+  version: 3,
   oauth: {
     clientParams: {/*...*/},
     scopes: ["io.cozy.files:GET"],

--- a/src/index.js
+++ b/src/index.js
@@ -141,7 +141,7 @@ class Client {
     this._authstate = AuthNone
     this._authcreds = null
     this._storage = null
-    this._version = null
+    this._version = options.version || null
     this._offline = null
 
     const token = options.token
@@ -235,7 +235,7 @@ class Client {
 
   isV2 () {
     if (!this._version) {
-      this._version = retry(() => fetch(`${this._url}/status/`), 3)()
+      return retry(() => fetch(`${this._url}/status/`), 3)()
         .then((res) => {
           if (!res.ok) {
             throw new Error('Could not fetch cozy status')
@@ -243,9 +243,12 @@ class Client {
             return res.json()
           }
         })
-        .then((status) => status.datasystem !== undefined)
+        .then((status) => {
+          this._version = status.datasystem !== undefined ? 2 : 3
+          return this.isV2()
+        })
     }
-    return this._version
+    return Promise.resolve(this._version === 2)
   }
 }
 


### PR DESCRIPTION
This feature add cozyVersion parameter.

The purpose is to delete [the request to the server '/status/'](https://github.com/cozy/cozy-client-js/blob/88a63b5b052fbe78e9e1835dc4dd61d1ab8c6504/src/index.js#L238) for the offline mode.