### PR TITLE
[WIP] feat: add cozy.client.accounts.create

### DIFF
--- a/src/accounts.js
+++ b/src/accounts.js
@@ -1,13 +1,13 @@
 import {cozyFetchJSON} from './fetch'
 
-export function create (cozy, konnector, login = '', password = '', name = '') {
-  return cozyFetchJSON(cozy, 'POST', '/data/io.cozy.accounts', {
+export function create (cozy, konnector, auth, name = '') {
+  return cozyFetchJSON(cozy, 'POST', '/data/io.cozy.accounts/', {
     name: name,
     account_type: konnector.vendorLink,
     status: 'PENDING',
     auth: {
-      login: login,
-      password: password
+      login: auth.login,
+      password: auth.password
     }
   })
 }

--- a/src/accounts.js
+++ b/src/accounts.js
@@ -1,8 +1,9 @@
 import {cozyFetchJSON} from './fetch'
 
-export function create (cozy, type, login = '', password = '') {
+export function create (cozy, konnector, login = '', password = '', name = '') {
   return cozyFetchJSON(cozy, 'POST', '/data/io.cozy.accounts', {
-    account_type: type,
+    name: name,
+    account_type: konnector.vendorLink,
     status: 'PENDING',
     auth: {
       login: login,

--- a/src/accounts.js
+++ b/src/accounts.js
@@ -1,0 +1,12 @@
+import {cozyFetchJSON} from './fetch'
+
+export function create (cozy, type, login = '', password = '') {
+  return cozyFetchJSON(cozy, 'POST', '/data/io.cozy.accounts', {
+    account_type: type,
+    status: 'PENDING',
+    auth: {
+      login: login,
+      password: password
+    }
+  })
+}

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ import 'babel-polyfill'
 import {unpromiser, retry, warn} from './utils'
 import {LocalStorage, MemoryStorage} from './auth_storage'
 import {AppToken as AppTokenV2, getAppToken as getAppTokenV2} from './auth_v2'
+import * as accounts from './accounts'
 import * as auth from './auth_v3'
 import * as data from './data'
 import * as mango from './mango'
@@ -26,6 +27,10 @@ const AuthOK = 3
 
 const defaultClientParams = {
   softwareID: 'github.com/cozy/cozy-client-js'
+}
+
+const accountsProto = {
+  create: accounts.create
 }
 
 const dataProto = {
@@ -116,6 +121,7 @@ const settingsProto = {
 
 class Client {
   constructor (options) {
+    this.accounts = {}
     this.data = {}
     this.files = {}
     this.intents = {}
@@ -168,6 +174,7 @@ class Client {
     this._url = url
 
     const disablePromises = !!options.disablePromises
+    addToProto(this, this.accounts, accountsProto, disablePromises)
     addToProto(this, this.data, dataProto, disablePromises)
     addToProto(this, this.auth, authProto, disablePromises)
     addToProto(this, this.files, filesProto, disablePromises)

--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,7 @@ import * as data from './data'
 import * as mango from './mango'
 import * as files from './files'
 import * as intents from './intents'
+import * as konnectors from './konnectors'
 import * as offline from './offline'
 import * as settings from './settings'
 import * as relations from './relations'
@@ -89,6 +90,14 @@ const intentsProto = {
   createService: intents.createService
 }
 
+const konnectorsProto = {
+  addAccount: konnectors.addAccount,
+  fetchManifest: konnectors.fetchManifest,
+  get: konnectors.get,
+  getBySlug: konnectors.getBySlug,
+  install: konnectors.install
+}
+
 const offlineProto = {
   init: offline.init,
   getDoctypes: offline.getDoctypes,
@@ -125,6 +134,7 @@ class Client {
     this.data = {}
     this.files = {}
     this.intents = {}
+    this.konnectors = {}
     this.offline = {}
     this.settings = {}
     this.auth = {
@@ -179,6 +189,7 @@ class Client {
     addToProto(this, this.auth, authProto, disablePromises)
     addToProto(this, this.files, filesProto, disablePromises)
     addToProto(this, this.intents, intentsProto, disablePromises)
+    addToProto(this, this.konnectors, konnectorsProto, disablePromises)
     addToProto(this, this.offline, offlineProto, disablePromises)
     addToProto(this, this.settings, settingsProto, disablePromises)
 

--- a/src/konnectors.js
+++ b/src/konnectors.js
@@ -1,0 +1,70 @@
+import {cozyFetchJSON} from './fetch'
+
+const STATE_READY = 'ready'
+
+export function addAccount (cozy, konnector, account) {
+  return Promise.resolve(konnector)
+}
+
+export function fetchManifest (cozy, source) {
+  return cozyFetchJSON(cozy, 'GET', `/konnectors/manifests?Source=${encodeURIComponent(source)}`)
+}
+
+let cachedSlugIndex
+function getSlugIndex (cozy) {
+  console.debug('cozy.client cachedSlugIndex is', cachedSlugIndex)
+  return cachedSlugIndex
+    ? Promise.resolve(cachedSlugIndex)
+      : cozy.data.defineIndex('io.cozy.konnectors', ['slug'])
+          .then(index => {
+            cachedSlugIndex = index
+            return index
+          })
+}
+
+export function get (cozy, id) {
+  if (!id) throw new Error('Missing `id` parameter')
+  return cozyFetchJSON(cozy, 'GET', `/data/io.cozy.konnectors/${encodeURIComponent(id)}`)
+}
+
+export function getBySlug (cozy, slug) {
+  if (!slug) throw new Error('Missing `slug` paramater')
+
+  return getSlugIndex(cozy)
+    .then(index => cozy.data.query(index, {selector: {slug: slug}}))
+    .then(list => list.length ? list[0] : null)
+}
+
+export function install (cozy, slug, source, timeout = 120000) {
+  if (!slug) throw new Error('Missing `slug` paramater for konnector')
+  if (!source) throw new Error('Missing `source` parameter for konnector')
+
+  return cozyFetchJSON(cozy, 'POST', `/konnectors/${slug}?Source=${encodeURIComponent(source)}`)
+      .then(konnector => new Promise((resolve, reject) => {
+        const idTimeout = setTimeout(() => {
+          reject(new Error('Konnector installation timed out'))
+        }, timeout)
+
+        // monitor the status of the connector
+        // TODO: replace by a polling abstraction utility.
+        const idInterval = setInterval(() => {
+          get(cozy, konnector._id)
+            .then(konnector => {
+              if (konnector.state === STATE_READY) {
+                clearTimeout(idTimeout)
+                clearInterval(idInterval)
+                resolve(konnector)
+              }
+            })
+            .catch(error => {
+              clearTimeout(idTimeout)
+              clearInterval(idInterval)
+              reject(error)
+            })
+        }, 5000)
+      }))
+}
+
+export function setFolder (cozy, konnector, file) {
+  return Promise.resolve(konnector)
+}


### PR DESCRIPTION
No need for tests as we are only encapsulating a `POST` request to `/data/io.cozy.accounts`, which is already tested.