### PR TITLE
feat: stronger postMessage handling in intents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - none yet
 
 ### Fixed
-- none yet
+- Safer communication protocol in intents.
 
 ### Added
 - `cancel()` method on service object returned by `cozy.client.intents.createService()``

--- a/src/intents.js
+++ b/src/intents.js
@@ -3,7 +3,7 @@ import {cozyFetchJSON} from './fetch'
 const intentClass = 'coz-intent'
 
 // inject iframe for service in given element
-function injectService (url, element, data) {
+function injectService (url, element, intent, data) {
   const document = element.ownerDocument
   if (!document) throw new Error('Cannot retrieve document object from given element')
 
@@ -23,7 +23,7 @@ function injectService (url, element, data) {
     const messageHandler = (event) => {
       if (event.origin !== serviceOrigin) return
 
-      if (event.data === 'intent:ready') {
+      if (event.data.type === `intent-${intent._id}:ready`) {
         handshaken = true
         return event.source.postMessage(data, event.origin)
       }
@@ -31,7 +31,7 @@ function injectService (url, element, data) {
       window.removeEventListener('message', messageHandler)
       iframe.parentNode.removeChild(iframe)
 
-      if (event.data === 'intent:error') {
+      if (event.data.type === `intent-${intent._id}:error`) {
         return reject(new Error('Intent error'))
       }
 
@@ -68,7 +68,7 @@ export function create (cozy, action, type, data = {}, permissions = []) {
         return Promise.reject(new Error('Unable to find a service'))
       }
 
-      return injectService(service.href, element, data)
+      return injectService(service.href, element, intent, data)
     })
   }
 
@@ -85,7 +85,7 @@ function listenClientData (intent, window) {
     }
 
     window.addEventListener('message', messageEventListener)
-    window.parent.postMessage('intent:ready', intent.attributes.client)
+    window.parent.postMessage(`intent-${intent._id}:ready`, intent.attributes.client)
   })
 }
 

--- a/src/intents.js
+++ b/src/intents.js
@@ -130,7 +130,9 @@ export function createService (cozy, intentId, serviceWindow) {
 
       // Prevent unfulfilled client promises when this window unloads for a
       // reason or another.
-      serviceWindow.addEventListener('unload', cancel)
+      serviceWindow.addEventListener('unload', () => {
+        if (!terminated) cancel()
+      })
 
       return listenClientData(intent, serviceWindow)
         .then(data => {

--- a/src/intents.js
+++ b/src/intents.js
@@ -100,7 +100,9 @@ function listenClientData (intent, window) {
     }
 
     window.addEventListener('message', messageEventListener)
-    window.parent.postMessage(`intent-${intent._id}:ready`, intent.attributes.client)
+    window.parent.postMessage({
+      type: `intent-${intent._id}:ready`
+    }, intent.attributes.client)
   })
 }
 

--- a/test/unit/intents.js
+++ b/test/unit/intents.js
@@ -282,7 +282,7 @@ describe('Intents', function () {
       }
 
       windowMock.parent.postMessage.callsFake(() => {
-        const messageEventListener = windowMock.addEventListener.firstCall.args[1]
+        const messageEventListener = windowMock.addEventListener.secondCall.args[1]
         windowMock.addEventListener.withArgs('message', messageEventListener).calledOnce.should.be.true()
 
         messageEventListener(clientHandshakeEventMessageMock)
@@ -334,7 +334,7 @@ describe('Intents', function () {
           }
 
           windowMock.parent.postMessage.callsFake(() => {
-            const messageEventListener = windowMock.addEventListener.firstCall.args[1]
+            const messageEventListener = windowMock.addEventListener.secondCall.args[1]
             messageEventListener(clientHandshakeEventMessageMock)
           })
 
@@ -359,7 +359,7 @@ describe('Intents', function () {
           }
 
           window.parent.postMessage.callsFake(() => {
-            const messageEventListener = window.addEventListener.firstCall.args[1]
+            const messageEventListener = window.addEventListener.secondCall.args[1]
             messageEventListener(clientHandshakeEventMessageMock)
           })
 
@@ -386,7 +386,7 @@ describe('Intents', function () {
           }
 
           windowMock.parent.postMessage.callsFake(() => {
-            const messageEventListener = windowMock.addEventListener.firstCall.args[1]
+            const messageEventListener = windowMock.addEventListener.secondCall.args[1]
             messageEventListener(clientHandshakeEventMessageMock)
           })
 
@@ -410,7 +410,7 @@ describe('Intents', function () {
           }
 
           windowMock.parent.postMessage.callsFake(() => {
-            const messageEventListener = windowMock.addEventListener.firstCall.args[1]
+            const messageEventListener = windowMock.addEventListener.secondCall.args[1]
             messageEventListener(clientHandshakeEventMessageMock)
           })
 
@@ -431,7 +431,7 @@ describe('Intents', function () {
           }
 
           window.parent.postMessage.callsFake(() => {
-            const messageEventListener = window.addEventListener.firstCall.args[1]
+            const messageEventListener = window.addEventListener.secondCall.args[1]
             messageEventListener(clientHandshakeEventMessageMock)
           })
 
@@ -454,7 +454,7 @@ describe('Intents', function () {
           }
 
           windowMock.parent.postMessage.callsFake(() => {
-            const messageEventListener = windowMock.addEventListener.firstCall.args[1]
+            const messageEventListener = windowMock.addEventListener.secondCall.args[1]
             messageEventListener(clientHandshakeEventMessageMock)
           })
 
@@ -480,7 +480,7 @@ describe('Intents', function () {
           }
 
           windowMock.parent.postMessage.callsFake(() => {
-            const messageEventListener = windowMock.addEventListener.firstCall.args[1]
+            const messageEventListener = windowMock.addEventListener.secondCall.args[1]
             messageEventListener(clientHandshakeEventMessageMock)
           })
 

--- a/test/unit/intents.js
+++ b/test/unit/intents.js
@@ -238,7 +238,10 @@ describe('Intents', function () {
 
       const resolveEventMessageMock = {
         origin: serviceUrl,
-        data: result,
+        data: {
+          type: 'intent-77bcc42c-0fd8-11e7-ac95-8f605f6e8338:done',
+          document: result
+        },
         source: iframeWindowMock
       }
 
@@ -348,8 +351,13 @@ describe('Intents', function () {
 
           service.terminate(result)
 
+          const messageMatch = sinon.match({
+            type: 'intent-77bcc42c-0fd8-11e7-ac95-8f605f6e8338:done',
+            document: result
+          })
+
           windowMock.parent.postMessage
-            .withArgs(result, expectedIntent.attributes.client).calledOnce.should.be.true()
+            .withArgs(messageMatch, expectedIntent.attributes.client).calledOnce.should.be.true()
         })
 
         it('should send result document to Client also with no params', async function () {
@@ -373,8 +381,13 @@ describe('Intents', function () {
 
           service.terminate(result)
 
+          const messageMatch = sinon.match({
+            type: 'intent-77bcc42c-0fd8-11e7-ac95-8f605f6e8338:done',
+            document: result
+          })
+
           window.parent.postMessage
-            .withArgs(result, expectedIntent.attributes.client).calledOnce.should.be.true()
+            .withArgs(messageMatch, expectedIntent.attributes.client).calledOnce.should.be.true()
 
           delete global.window
         })
@@ -424,8 +437,10 @@ describe('Intents', function () {
 
           service.cancel()
 
+          const messageMatch = sinon.match({type: 'intent-77bcc42c-0fd8-11e7-ac95-8f605f6e8338:cancel'})
+
           windowMock.parent.postMessage
-            .withArgs(null, expectedIntent.attributes.client).calledOnce.should.be.true()
+            .withArgs(messageMatch, expectedIntent.attributes.client).calledOnce.should.be.true()
         })
 
         it('should send null to Client also with no parameters', async function () {
@@ -445,8 +460,10 @@ describe('Intents', function () {
 
           service.cancel()
 
+          const messageMatch = sinon.match({type: 'intent-77bcc42c-0fd8-11e7-ac95-8f605f6e8338:cancel'})
+
           window.parent.postMessage
-            .withArgs(null, expectedIntent.attributes.client).calledOnce.should.be.true()
+            .withArgs(messageMatch, expectedIntent.attributes.client).calledOnce.should.be.true()
 
           delete global.window
         })

--- a/test/unit/intents.js
+++ b/test/unit/intents.js
@@ -282,6 +282,33 @@ describe('Intents', function () {
 
     beforeEach(mock.mockAPI('GetIntent'))
 
+    it('starts handshake', async function () {
+      const windowMock = mockWindow()
+
+      const clientHandshakeEventMessageMock = {
+        origin: expectedIntent.attributes.client,
+        data: { foo: 'bar' }
+      }
+
+      windowMock.parent.postMessage.callsFake(() => {
+        const messageEventListener = windowMock.addEventListener.secondCall.args[1]
+        windowMock.addEventListener.withArgs('message', messageEventListener).calledOnce.should.be.true()
+
+        messageEventListener(clientHandshakeEventMessageMock)
+        windowMock.removeEventListener.withArgs('message', messageEventListener).calledOnce.should.be.true()
+      })
+
+      return cozy.client.intents.createService(expectedIntent._id, windowMock)
+        .then(service => {
+          const messageMatch = sinon.match({
+            type: 'intent-77bcc42c-0fd8-11e7-ac95-8f605f6e8338:ready'
+          })
+
+          windowMock.parent.postMessage
+            .withArgs(messageMatch, expectedIntent.attributes.client).calledOnce.should.be.true()
+        })
+    })
+
     it('should manage handshake', async function () {
       const windowMock = mockWindow()
 

--- a/test/unit/intents.js
+++ b/test/unit/intents.js
@@ -142,7 +142,9 @@ describe('Intents', function () {
 
       const handshakeEventMessageMock = {
         origin: serviceUrl,
-        data: 'intent:ready',
+        data: {
+          type: 'intent-77bcc42c-0fd8-11e7-ac95-8f605f6e8338:ready'
+        },
         source: iframeWindowMock
       }
 
@@ -195,7 +197,9 @@ describe('Intents', function () {
 
       const handshakeEventMessageMock = {
         origin: serviceUrl,
-        data: 'intent:error',
+        data: {
+          type: 'intent-77bcc42c-0fd8-11e7-ac95-8f605f6e8338:error'
+        },
         source: iframeWindowMock
       }
 
@@ -222,7 +226,9 @@ describe('Intents', function () {
 
       const handshakeEventMessageMock = {
         origin: serviceUrl,
-        data: 'intent:ready',
+        data: {
+          type: 'intent-77bcc42c-0fd8-11e7-ac95-8f605f6e8338:ready'
+        },
         source: iframeWindowMock
       }
 


### PR DESCRIPTION
Interesting case in onboarding, with four services, all able of starting an intent. When one of the intents was not properly ended or cancelled (when the modal is closed by clicking on its overlay for example), the listener over postMessage events was still listening for `intent:ready` message and still responding with its given data (here: the konnector slug).

Consquence : if an intent to EDF konnector was open and "closed" by a click on modal overlay, all future intents were invariably serving the EDF konnector, because of the old listerner always present.

To solve this issue, my first thought was to listen the iframe itself and remove the listener when it was removed from DOM, but security/permission issues occured. So I made two things :

 * The service part now listen for the `unload` event "inside" the iframe, and cancel the intent when this event occurs. But we could still have the case when the service fail to initialize before being able to listen to this event or cancelling the intent. So we need to be able to live with an "orphan" window listener on the client side.
 * The solution I implemented is that now every message brings the related intent id into a new `type` property. So now every message listener is no more listening to `intent:ready` but to something like `{type: 'intent-77bcc42c-0fd8-11e7-ac95-8f605f6e8338:ready'}`, to ensure that it will react to message targeting it only.
 * This have no effects to existing code, it is only internal implementation.