### PR TITLE
fix: not enough perm to share collections

### DIFF
--- a/src/files.js
+++ b/src/files.js
@@ -245,7 +245,7 @@ export function getFilePath (cozy, file = {}, folder) {
   return `${folderPath}${file.name}`
 }
 
-export function getShareLink (cozy, id) {
+export function getCollectionShareLink (cozy, id, collectionType) {
   if (!id) {
     return Promise.reject(Error('An id should be provided to create a share link'))
   }
@@ -254,8 +254,14 @@ export function getShareLink (cozy, id) {
       type: 'io.cozy.permissions',
       attributes: {
         permissions: {
-          share: {
+          files: {
             type: 'io.cozy.files',
+            verbs: ['GET'],
+            values: [id],
+            selector: 'referenced_by'
+          },
+          collection: {
+            type: collectionType,
             verbs: ['GET'],
             values: [id]
           }

--- a/src/index.js
+++ b/src/index.js
@@ -75,7 +75,7 @@ const filesProto = {
   getDownloadLinkByPath: files.getDownloadLinkByPath,
   getArchiveLink: files.getArchiveLink,
   getFilePath: files.getFilePath,
-  getShareLink: files.getShareLink,
+  getCollectionShareLink: files.getCollectionShareLink,
   listTrash: files.listTrash,
   clearTrash: files.clearTrash,
   restoreById: files.restoreById,

--- a/test/integration/files.js
+++ b/test/integration/files.js
@@ -266,11 +266,16 @@ describe('files API', async function () {
 
   describe('share', () => {
     it('should get `sharecode` and `id` to create a share link', async () => {
-      const created = await cozy.client.files.create('foo', {
+      const document = await cozy.client.files.create('foo', {
         name: 'to be shared',
         contentType: 'application/json'
       })
-      const data = await cozy.client.files.getShareLink(created._id)
+      const collection = await cozy.client.data.create('io.cozy.testreferencer', {
+        name: 'foo_' + random()
+      })
+
+      await cozy.client.data.addReferencedFiles(collection, document._id)
+      const data = await cozy.client.files.getCollectionShareLink(document._id, 'io.cozy.testreferencer')
 
       data.should.have.properties(['sharecode', 'id'])
     })


### PR DESCRIPTION
When developing https://github.com/cozy/cozy-photos-v3/pull/77 I realized that we miss some permissions to access everything needed.