### PR TITLE
feat: make possible for the service to specify the size of the intent modale

### DIFF
--- a/docs/intents-api.md
+++ b/docs/intents-api.md
@@ -25,14 +25,15 @@ If `intentId` and `window` parameters are not provided the method will try to re
 It returns a *service* object, which provides the following methods :
  * `getData()`: returns the data passed to the service by the client.
  * `getIntent()`: returns the intent
- * `setSize(doc)`: forces the size of the intent modale to a given minWidth, width, maxWidth, minHeight, height, maxHeight, or dimensions of a given dom element.
- ```javascript
- service.setSize({
-    maxHeight: '300px'
+ * `resizeClient(doc)`: forces the size of the intent modale to a given minWidth, width, maxWidth, minHeight, height, maxHeight, or dimensions of a given element.
+ ```js
+ // resize the client ot 300 pixels max height
+ service.resizeClient({
+    maxHeight: 300
  })
  // or
- service.setSize({
-    dom: document.querySelector('.class')
+ service.resizeClient({
+    element: document.querySelector('.class')
  })
  ```
  * `terminate(doc)`: ends the intent process by passing to the client the resulting document `doc`. An intent service may only be terminated once.

--- a/docs/intents-api.md
+++ b/docs/intents-api.md
@@ -25,6 +25,16 @@ If `intentId` and `window` parameters are not provided the method will try to re
 It returns a *service* object, which provides the following methods :
  * `getData()`: returns the data passed to the service by the client.
  * `getIntent()`: returns the intent
+ * `setSize(doc)`: forces the size of the intent modale to a given minWidth, width, maxWidth, minHeight, height, maxHeight, or dimensions of a given dom element.
+ ```javascript
+ service.setSize({
+    maxHeight: '300px'
+ })
+ // or
+ service.setSize({
+    dom: document.querySelector('.class')
+ })
+ ```
  * `terminate(doc)`: ends the intent process by passing to the client the resulting document `doc`. An intent service may only be terminated once.
  * `cancel()`: ends the intent process by passing a `null` value to the client. This method terminate the intent service the same way that `terminate()`.
  * `throw(error)`: throw an error to client and causes the intent promise rejection.

--- a/src/intents.js
+++ b/src/intents.js
@@ -46,6 +46,12 @@ function injectService (url, element, intent, data) {
         return event.source.postMessage(data, event.origin)
       }
 
+      if (handshaken && event.data.type === `intent-${intent._id}:size`) {
+        if (event.data.document.width) element.style.width = event.data.document.width
+        if (event.data.document.height) element.style.height = event.data.document.height
+        return true
+      }
+
       window.removeEventListener('message', messageHandler)
       iframe.parentNode.removeChild(iframe)
 
@@ -142,6 +148,11 @@ export function createService (cozy, intentId, serviceWindow) {
         serviceWindow.parent.postMessage(message, intent.attributes.client)
       }
 
+      const setSize = (message) => {
+        if (terminated) throw new Error('Intent service has already been terminated')
+        serviceWindow.parent.postMessage(message, intent.attributes.client)
+      }
+
       const cancel = () => {
         terminate({type: `intent-${intent._id}:cancel`})
       }
@@ -164,6 +175,10 @@ export function createService (cozy, intentId, serviceWindow) {
             throw: error => terminate({
               type: `intent-${intent._id}:error`,
               error: errorSerializer.serialize(error)
+            }),
+            setSize: (doc) => setSize({
+              type: `intent-${intent._id}:size`,
+              document: doc
             }),
             cancel: cancel
           }

--- a/src/intents.js
+++ b/src/intents.js
@@ -50,6 +50,7 @@ function injectService (url, element, intent, data) {
         ['width', 'height', 'maxWidth', 'maxHeight', 'minWidth', 'minHeight'].forEach(prop => {
           if (event.data.document[prop]) element.style[prop] = event.data.document[prop]
         })
+
         return true
       }
 
@@ -151,6 +152,14 @@ export function createService (cozy, intentId, serviceWindow) {
 
       const setSize = (message) => {
         if (terminated) throw new Error('Intent service has already been terminated')
+
+        // if a dom element is passed, calculate its size and convert it in css properties
+        if (message.document.dom) {
+          message.document.maxHeight = `${message.document.dom.clientHeight}px`
+          message.document.maxWidth = `${message.document.dom.clientWidth}px`
+          message.document.dom = undefined
+        }
+
         serviceWindow.parent.postMessage(message, intent.attributes.client)
       }
 

--- a/src/intents.js
+++ b/src/intents.js
@@ -48,7 +48,7 @@ function injectService (url, element, intent, data) {
 
       if (handshaken && event.data.type === `intent-${intent._id}:size`) {
         ['width', 'height', 'maxWidth', 'maxHeight', 'minWidth', 'minHeight'].forEach(prop => {
-          if (event.data.document[prop]) element.style[prop] = event.data.document[prop]
+          if (event.data.document[prop]) element.style[prop] = `${event.data.document[prop]}px`
         })
 
         return true
@@ -145,19 +145,19 @@ export function createService (cozy, intentId, serviceWindow) {
       let terminated = false
 
       const terminate = (message) => {
-        if (terminated) throw new Error('Intent service has already been terminated')
+        if (terminated) throw new Error('Intent service has been terminated')
         terminated = true
         serviceWindow.parent.postMessage(message, intent.attributes.client)
       }
 
-      const setSize = (message) => {
-        if (terminated) throw new Error('Intent service has already been terminated')
+      const resizeClient = (message) => {
+        if (terminated) throw new Error('Intent service has been terminated')
 
         // if a dom element is passed, calculate its size and convert it in css properties
-        if (message.document.dom) {
-          message.document.maxHeight = `${message.document.dom.clientHeight}px`
-          message.document.maxWidth = `${message.document.dom.clientWidth}px`
-          message.document.dom = undefined
+        if (message.dimensions.element) {
+          message.dimensions.maxHeight = message.dimensions.element.clientHeight
+          message.dimensions.maxWidth = message.dimensions.element.clientWidth
+          message.dimensions.element = undefined
         }
 
         serviceWindow.parent.postMessage(message, intent.attributes.client)
@@ -186,9 +186,9 @@ export function createService (cozy, intentId, serviceWindow) {
               type: `intent-${intent._id}:error`,
               error: errorSerializer.serialize(error)
             }),
-            setSize: (doc) => setSize({
+            resizeClient: (dimensions) => resizeClient({
               type: `intent-${intent._id}:size`,
-              document: doc
+              dimensions
             }),
             cancel: cancel
           }

--- a/src/intents.js
+++ b/src/intents.js
@@ -47,8 +47,9 @@ function injectService (url, element, intent, data) {
       }
 
       if (handshaken && event.data.type === `intent-${intent._id}:size`) {
-        if (event.data.document.width) element.style.width = event.data.document.width
-        if (event.data.document.height) element.style.height = event.data.document.height
+        ['width', 'height', 'maxWidth', 'maxHeight', 'minWidth', 'minHeight'].forEach(prop => {
+          if (event.data.document[prop]) element.style[prop] = event.data.document[prop]
+        })
         return true
       }
 

--- a/src/intents.js
+++ b/src/intents.js
@@ -47,7 +47,7 @@ function injectService (url, element, intent, data) {
       }
 
       if (handshaken && event.data.type === `intent-${intent._id}:size`) {
-        ['width', 'height', 'maxWidth', 'maxHeight', 'minWidth', 'minHeight'].forEach(prop => {
+        ['width', 'height', 'maxWidth', 'maxHeight'].forEach(prop => {
           if (event.data.document[prop]) element.style[prop] = `${event.data.document[prop]}px`
         })
 

--- a/test/unit/intents.js
+++ b/test/unit/intents.js
@@ -372,6 +372,72 @@ describe('Intents', function () {
     })
 
     describe('Service', function () {
+      describe('ResizeClient', function () {
+        it('should send provided sizes to the client', async function () {
+          const windowMock = mockWindow()
+
+          const clientHandshakeEventMessageMock = {
+            origin: expectedIntent.attributes.client,
+            data: { foo: 'bar' }
+          }
+
+          windowMock.parent.postMessage.callsFake(() => {
+            const messageEventListener = windowMock.addEventListener.secondCall.args[1]
+            messageEventListener(clientHandshakeEventMessageMock)
+          })
+
+          const service = await cozy.client.intents.createService(expectedIntent._id, windowMock)
+
+          service.resizeClient({
+            width: 100,
+            height: 200
+          })
+
+          const messageMatch = sinon.match({
+            type: 'intent-77bcc42c-0fd8-11e7-ac95-8f605f6e8338:size',
+            dimensions: {
+              width: 100,
+              height: 200
+            }
+          })
+
+          windowMock.parent.postMessage
+            .withArgs(messageMatch, expectedIntent.attributes.client).calledOnce.should.be.true()
+        })
+        it('should calculate width and height from a provided dom element', async function () {
+          const windowMock = mockWindow()
+
+          const clientHandshakeEventMessageMock = {
+            origin: expectedIntent.attributes.client,
+            data: { foo: 'bar' }
+          }
+
+          windowMock.parent.postMessage.callsFake(() => {
+            const messageEventListener = windowMock.addEventListener.secondCall.args[1]
+            messageEventListener(clientHandshakeEventMessageMock)
+          })
+
+          const service = await cozy.client.intents.createService(expectedIntent._id, windowMock)
+
+          service.resizeClient({
+            element: {
+              clientHeight: 10,
+              clientWidth: 13
+            }
+          })
+
+          const messageMatch = sinon.match({
+            type: 'intent-77bcc42c-0fd8-11e7-ac95-8f605f6e8338:size',
+            dimensions: {
+              maxWidth: 13,
+              maxHeight: 10
+            }
+          })
+
+          windowMock.parent.postMessage
+            .withArgs(messageMatch, expectedIntent.attributes.client).calledOnce.should.be.true()
+        })
+      })
       describe('Terminate', function () {
         it('should send result document to Client', async function () {
           const windowMock = mockWindow()
@@ -458,7 +524,7 @@ describe('Intents', function () {
 
           should.throws(() => {
             service.terminate(result)
-          }, /Intent service has already been terminated/)
+          }, /Intent service has been terminated/)
         })
       })
 
@@ -530,7 +596,7 @@ describe('Intents', function () {
 
           should.throws(() => {
             service.cancel()
-          }, /Intent service has already been terminated/)
+          }, /Intent service has been terminated/)
         })
 
         it('should forbbid further calls to terminate()', async function () {
@@ -556,7 +622,7 @@ describe('Intents', function () {
 
           should.throws(() => {
             service.terminate(result)
-          }, /Intent service has already been terminated/)
+          }, /Intent service has been terminated/)
         })
       })
 
@@ -614,7 +680,7 @@ describe('Intents', function () {
 
           should.throws(() => {
             service.cancel()
-          }, /Intent service has already been terminated/)
+          }, /Intent service has been terminated/)
         })
 
         it('should forbbid further calls to terminate()', async function () {
@@ -640,7 +706,7 @@ describe('Intents', function () {
 
           should.throws(() => {
             service.terminate(result)
-          }, /Intent service has already been terminated/)
+          }, /Intent service has been terminated/)
         })
       })
     })


### PR DESCRIPTION
The service can make a call to service to set the size of its modale : 
```javascript
cozy.client.intents.createService(intent, window)
.then(service => {
  service.setSize({width: '400px', height: '400px'})
})
```

The service is responsible to make the modale displayable on screen in different possible resolutions (mobile, desktop). The client application requesting the intent is still responsible for the display of the modal and the default size of it, if the service does not request any special modale size.