### PR TITLE
Add cozy.client.files.query and fetchReferencedFiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Add a `intentService.throw(error)` method to throw an error on client.
 - Add a `getArchiveLinkByIds` method to create a zip with files identified by their ids.
+- Add a `fetchReferencedFiles` method to fetch the files related to a doc.
+- Add a `cozy.client.files.query` method to fetch files using a mango query
 
 ### Removed
 - none yet

--- a/docs/files-api.md
+++ b/docs/files-api.md
@@ -348,3 +348,30 @@ const href = await cozy.client.files.getArchiveLinkByIds(["1592673"], "secretpro
 (see cozy-stack [documentation](https://cozy.github.io/cozy-stack/references-docs-in-vfs.html) for more details).
 
 It returns a promise for a list of filesIds. Files must then be fetched separately.
+
+### `cozy.client.data.fetchReferencedFiles(doc)`
+
+`cozy.client.data.fetchReferencedFiles(doc)` fetches the files bound to the document.
+(see cozy-stack [documentation](https://cozy.github.io/cozy-stack/references-docs-in-vfs.html) for more details).
+
+It returns a promise for a list of files.
+
+### `cozy.client.files.query(indexReference, query)`
+
+`cozy.client.files.query(indexReference, query)` find files using an index.
+
+It returns a promise with a list of files matching the query. Results will be returned in the order defined for the index.
+
+- `query` is an object with the following fields:
+  * `selector`: a mango selector
+  * `limit`: maximum number of results
+  * `skip`: ignore the first x results (pagination)
+  * `wholeResponse`: when set to true, the whole query response will be returned instead of just the docs. This is useful when paginating, because you'll get the `next` property in the response object.
+
+```javascript
+const results = await cozy.client.files.query(photosByDate, {
+  "selector": {"class": "image"},
+  "limit": 3,
+  "skip": 1
+})
+```

--- a/src/fetch.js
+++ b/src/fetch.js
@@ -49,6 +49,16 @@ function cozyFetchWithAuth (cozy, fullpath, options, credentials) {
 }
 
 export function cozyFetchJSON (cozy, method, path, body, options = {}) {
+  return fetchJSON(cozy, method, path, body, options)
+    .then(handleJSONResponse)
+}
+
+export function cozyFetchRawJSON (cozy, method, path, body, options = {}) {
+  return fetchJSON(cozy, method, path, body, options)
+    .then(response => handleJSONResponse(response, false))
+}
+
+function fetchJSON (cozy, method, path, body, options = {}) {
   options.method = method
 
   const headers = options.headers = options.headers || {}
@@ -65,7 +75,6 @@ export function cozyFetchJSON (cozy, method, path, body, options = {}) {
   }
 
   return cozyFetch(cozy, path, options)
-    .then(handleJSONResponse)
 }
 
 function handleResponse (res) {
@@ -84,7 +93,7 @@ function handleResponse (res) {
   })
 }
 
-function handleJSONResponse (res) {
+function handleJSONResponse (res, processJSONAPI = true) {
   const contentType = res.headers.get('content-type')
   if (!contentType || contentType.indexOf('json') < 0) {
     return res.text((data) => {
@@ -93,7 +102,7 @@ function handleJSONResponse (res) {
   }
 
   const json = res.json()
-  if (contentType.indexOf('application/vnd.api+json') === 0) {
+  if (contentType.indexOf('application/vnd.api+json') === 0 && processJSONAPI) {
     return json.then(jsonapi)
   } else {
     return json

--- a/src/index.js
+++ b/src/index.js
@@ -82,6 +82,7 @@ const filesProto = {
   getArchiveLinkByIds: files.getArchiveLinkByIds,
   getFilePath: files.getFilePath,
   getCollectionShareLink: files.getCollectionShareLink,
+  query: mango.queryFiles,
   listTrash: files.listTrash,
   clearTrash: files.clearTrash,
   restoreById: files.restoreById,

--- a/src/index.js
+++ b/src/index.js
@@ -42,6 +42,7 @@ const dataProto = {
   addReferencedFiles: relations.addReferencedFiles,
   removeReferencedFiles: relations.removeReferencedFiles,
   listReferencedFiles: relations.listReferencedFiles,
+  fetchReferencedFiles: relations.fetchReferencedFiles,
   destroy: function (...args) {
     warn('destroy is deprecated, use cozy.data.delete instead.')
     return data._delete(...args)

--- a/src/mango.js
+++ b/src/mango.js
@@ -29,6 +29,12 @@ export function query (cozy, indexRef, options) {
   })
 }
 
+export function queryFiles (cozy, indexRef, options) {
+  const opts = getV3Options(indexRef, options)
+  return cozyFetchJSON(cozy, 'POST', '/files/_find', opts)
+    .then((response) => options.wholeResponse ? response : response.docs)
+}
+
 // Internals
 
 const VALUEOPERATORS = ['$eq', '$gt', '$gte', '$lt', '$lte']
@@ -81,6 +87,14 @@ function queryV2 (cozy, indexRef, options) {
 
 // queryV3 is equivalent to query but only works for V3
 function queryV3 (cozy, indexRef, options) {
+  const opts = getV3Options(indexRef, options)
+
+  let path = createPath(cozy, false, indexRef.doctype, '_find')
+  return cozyFetchJSON(cozy, 'POST', path, opts)
+    .then((response) => options.wholeResponse ? response : response.docs)
+}
+
+function getV3Options (indexRef, options) {
   if (indexRef.type !== 'mango') {
     throw new Error('indexRef should be the return value of defineIndexV3')
   }
@@ -98,9 +112,7 @@ function queryV3 (cozy, indexRef, options) {
     opts.sort = indexRef.fields.map(f => ({ [f]: 'desc' }))
   }
 
-  let path = createPath(cozy, false, indexRef.doctype, '_find')
-  return cozyFetchJSON(cozy, 'POST', path, opts)
-    .then((response) => options.wholeResponse ? response : response.docs)
+  return opts
 }
 
 // misc

--- a/src/mango.js
+++ b/src/mango.js
@@ -1,6 +1,6 @@
 import {warn, createPath} from './utils'
 import {normalizeDoctype} from './doctypes'
-import {cozyFetchJSON} from './fetch'
+import {cozyFetchJSON, cozyFetchRawJSON} from './fetch'
 
 export function defineIndex (cozy, doctype, fields) {
   return cozy.isV2().then((isV2) => {
@@ -31,7 +31,7 @@ export function query (cozy, indexRef, options) {
 
 export function queryFiles (cozy, indexRef, options) {
   const opts = getV3Options(indexRef, options)
-  return cozyFetchJSON(cozy, 'POST', '/files/_find', opts)
+  return cozyFetchRawJSON(cozy, 'POST', '/files/_find', opts)
     .then((response) => options.wholeResponse ? response : response.docs)
 }
 

--- a/src/relations.js
+++ b/src/relations.js
@@ -1,4 +1,5 @@
-import {cozyFetchJSON} from './fetch'
+import { cozyFetchJSON } from './fetch'
+import { encodeQuery } from './utils'
 import { DOCTYPE_FILES } from './doctypes'
 
 function updateRelations (verb) {
@@ -15,14 +16,18 @@ function updateRelations (verb) {
 export const addReferencedFiles = updateRelations('POST')
 export const removeReferencedFiles = updateRelations('DELETE')
 
-export function listReferencedFiles (cozy, doc) {
+export function listReferencedFiles (cozy, doc, options) {
   if (!doc) throw new Error('missing doc argument')
-  return cozyFetchJSON(cozy, 'GET', makeReferencesPath(doc))
+  return cozyFetchJSON(cozy, 'GET', makeReferencesPath(doc, options))
     .then((files) => files.map((file) => file._id))
 }
 
-function makeReferencesPath (doc) {
+function makeReferencesPath (doc, options) {
   const type = encodeURIComponent(doc._type)
   const id = encodeURIComponent(doc._id)
-  return `/data/${type}/${id}/relationships/references`
+  let q = encodeQuery(options)
+  if (q !== '') {
+    q = '?' + q
+  }
+  return `/data/${type}/${id}/relationships/references${q}`
 }

--- a/src/relations.js
+++ b/src/relations.js
@@ -1,5 +1,4 @@
-import { cozyFetchJSON } from './fetch'
-import { encodeQuery } from './utils'
+import { cozyFetchJSON, cozyFetchRawJSON } from './fetch'
 import { DOCTYPE_FILES } from './doctypes'
 
 function updateRelations (verb) {
@@ -16,18 +15,20 @@ function updateRelations (verb) {
 export const addReferencedFiles = updateRelations('POST')
 export const removeReferencedFiles = updateRelations('DELETE')
 
-export function listReferencedFiles (cozy, doc, options) {
+export function listReferencedFiles (cozy, doc) {
   if (!doc) throw new Error('missing doc argument')
-  return cozyFetchJSON(cozy, 'GET', makeReferencesPath(doc, options))
+  return cozyFetchJSON(cozy, 'GET', makeReferencesPath(doc))
     .then((files) => files.map((file) => file._id))
 }
 
-function makeReferencesPath (doc, options) {
+export function fetchReferencedFiles (cozy, doc, options) {
+  if (!doc) throw new Error('missing doc argument')
+  const params = Object.keys(options).map(key => `&page[${key}]=${options[key]}`).join('')
+  return cozyFetchRawJSON(cozy, 'GET', `${makeReferencesPath(doc)}?include=files${params}`)
+}
+
+function makeReferencesPath (doc) {
   const type = encodeURIComponent(doc._type)
   const id = encodeURIComponent(doc._id)
-  let q = encodeQuery(options)
-  if (q !== '') {
-    q = '?' + q
-  }
-  return `/data/${type}/${id}/relationships/references${q}`
+  return `/data/${type}/${id}/relationships/references`
 }


### PR DESCRIPTION
### `cozy.client.data.fetchReferencedFiles(doc)`

`cozy.client.data.fetchReferencedFiles(doc)` fetches the files bound to the document.
(see cozy-stack [documentation](https://cozy.github.io/cozy-stack/references-docs-in-vfs.html) for more details).

It returns a promise for a list of files.

### `cozy.client.files.query(indexReference, query)`

`cozy.client.files.query(indexReference, query)` find files using an index.

It returns a promise with a list of files matching the query. Results will be returned in the order defined for the index.

- `query` is an object with the following fields:
  * `selector`: a mango selector
  * `limit`: maximum number of results
  * `skip`: ignore the first x results (pagination)
  * `wholeResponse`: when set to true, the whole query response will be returned instead of just the docs. This is useful when paginating, because you'll get the `next` property in the response object.

```javascript
const results = await cozy.client.files.query(photosByDate, {
  "selector": {"class": "image"},
  "limit": 3,
  "skip": 1
})
```