### PR TITLE
Intents improvements (onReadyCallback, exposeFrameRemoval)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,8 +26,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - none yet
 
 ### Added
-- Add an exposeFrameRemoval method to the service to terminate him without removing the intent DOM node directly but by providing the function to do it to the client.
-- Add an onReadyCallback optional argument to the create method in order to allow providing a callback function to be run when the intent iframe will be loaded (iframe onload listener).
+- Handle `exposeIntentFrameRemoval` data flag to terminate the service without removing the intent DOM node directly but by providing the removal function to the client.
+- Add an `onReadyCallback` optional argument to the create method in order to allow providing a callback function to be run when the intent iframe will be loaded (iframe `onload` listener).
 
 ### Removed
 - none yet

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,20 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Removed
 - none yet
 
+## [v0.3.10] - 2017-07-XX
+### Changed
+- none yet
+
+### Fixed
+- none yet
+
+### Added
+- Add an exposeFrameRemoval method to the service to terminate him without removing the intent DOM node directly but by providing the function to do it to the client.
+- Add an onReadyCallback optional argument to the create method in order to allow providing a callback function to be run when the intent iframe will be loaded (iframe onload listener).
+
+### Removed
+- none yet
+
 
 ## [v0.3.9] - 2017-07-10
 ### Added

--- a/docs/intents-api.md
+++ b/docs/intents-api.md
@@ -28,14 +28,14 @@ cozy.client.intents.create('EDIT', 'io.cozy.photos', {action: 'crop', width: 100
   })
 ```
 
-Example when using `service.exposeFrameRemoval()` method:
+Example to use `removeIntentFrame()` method (by passing the flag `exposeIntentFrameRemoval` flag):
 ```js
-cozy.client.intents.create('EDIT', 'io.cozy.photos', {action: 'crop', width: 100, height: 100})
+cozy.client.intents.create('EDIT', 'io.cozy.photos', {action: 'crop', width: 100, height: 100, exposeIntentFrameRemoval: true})
   .start(document.getElementById('intent-service-wrapper'))
-  .then({removeIntentFrame, doc} => { // after service.exposeFrameRemoval(doc)
+  .then({removeIntentFrame, doc} => { // after service.terminate(doc)
       // Code to be run before removing the terminated intent iframe
       removeIntentFrame()
-      // Other code
+      // Other code, use doc
   })
 ```
 
@@ -60,7 +60,8 @@ It returns a *service* object, which provides the following methods :
  })
  ```
  * `terminate(doc)`: ends the intent process by passing to the client the resulting document `doc`. An intent service may only be terminated once.
- * `exposeFrameRemoval(doc)`: ends the intent process by passing to the client an object with as properties a function named `removeIntentFrame` to remove the iframe DOM node (in order to be run by the client later on) and the resulting document `doc`. The intent service will be terminated as in the `terminate` method. This method could be useful to animate an intent closing and remove the iframe node at the animation ending.
+   > If a boolean `exposeIntentFrameRemoval` is found as `true` in the data sent by the client, the `terminate()` method will return an object with as properties a function named `removeIntentFrame` to remove the iframe DOM node (in order to be run by the client later on) and the resulting document `doc`. This could be useful to animate an intent closing and remove the iframe node at the animation ending.
+
  * `cancel()`: ends the intent process by passing a `null` value to the client. This method terminate the intent service the same way that `terminate()`.
  * `throw(error)`: throw an error to client and causes the intent promise rejection.
 

--- a/docs/intents-api.md
+++ b/docs/intents-api.md
@@ -4,6 +4,8 @@
 
 `cozy.client.intents.create(action, doctype [, data, permissions])` create an intent. It returns a modified Promise for the intent document, having a custom `start(element)` method. This method interacts with the DOM to append an iframe to the given HTML element. This iframe will provide an access to an app, which will serve a service page able to manage the intent action for the intent doctype. The `start(element)` method returns a promise for the result document provided by intent service.
 
+> __On Intent ready callback:__ This `start` method also takes a second optional argument which is a callback function (`start(element, onReadyCallback)`). When provided, this function will be run when the intent iframe will be completely loaded (using the `onload` iframe listener). This callback could be useful to run a client code only when the intent iframe is ready and loaded.
+
 An intent has to be created everytime an app need to perform an action over a doctype for wich it does not have permission. For example, the Cozy Drive app should create an intent to `pick` a `io.cozy.contacts` document. The cozy-stack will determines which app can offer a service to resolve the intent. It's this service's URL that will be passed to the iframe `src` property.
 
 Once the intent process is terminated by service, the iframe is removed from DOM.
@@ -15,6 +17,27 @@ cozy.client.intents.create('EDIT', 'io.cozy.photos', {action: 'crop', width: 100
 ```
 
 See cozy-stack [documentation](https://cozy.github.io/cozy-stack/intents.html) for more details.
+
+You can also use `.then` to run some code after the intents is terminated like following:
+
+```js
+cozy.client.intents.create('EDIT', 'io.cozy.photos', {action: 'crop', width: 100, height: 100})
+  .start(document.getElementById('intent-service-wrapper'))
+  .then(doc => { // after service.terminate(doc)
+      // code to use the doc
+  })
+```
+
+Example when using `service.exposeFrameRemoval()` method:
+```js
+cozy.client.intents.create('EDIT', 'io.cozy.photos', {action: 'crop', width: 100, height: 100})
+  .start(document.getElementById('intent-service-wrapper'))
+  .then({removeIntentFrame, doc} => { // after service.exposeFrameRemoval(doc)
+      // Code to be run before removing the terminated intent iframe
+      removeIntentFrame()
+      // Other code
+  })
+```
 
 ### `cozy.client.intents.createService()`
 
@@ -37,6 +60,7 @@ It returns a *service* object, which provides the following methods :
  })
  ```
  * `terminate(doc)`: ends the intent process by passing to the client the resulting document `doc`. An intent service may only be terminated once.
+ * `exposeFrameRemoval(doc)`: ends the intent process by passing to the client an object with as properties a function named `removeIntentFrame` to remove the iframe DOM node (in order to be run by the client later on) and the resulting document `doc`. The intent service will be terminated as in the `terminate` method. This method could be useful to animate an intent closing and remove the iframe node at the animation ending.
  * `cancel()`: ends the intent process by passing a `null` value to the client. This method terminate the intent service the same way that `terminate()`.
  * `throw(error)`: throw an error to client and causes the intent promise rejection.
 

--- a/src/intents.js
+++ b/src/intents.js
@@ -64,7 +64,15 @@ function injectService (url, element, intent, data, onReadyCallback) {
       }
 
       window.removeEventListener('message', messageHandler)
-      iframe.parentNode.removeChild(iframe)
+      const removeIntentFrame = () => {
+        iframe.parentNode.removeChild(iframe)
+      }
+
+      if (handshaken && event.data.type === `intent-${intent._id}:exposeFrameRemoval`) {
+        return resolve({removeIntentFrame, doc: event.data.document})
+      }
+
+      removeIntentFrame()
 
       if (event.data.type === `intent-${intent._id}:error`) {
         return reject(errorSerializer.deserialize(event.data.error))
@@ -194,6 +202,9 @@ export function createService (cozy, intentId, serviceWindow) {
             terminate: (doc) => terminate({
               type: `intent-${intent._id}:done`,
               document: doc
+            }),
+            exposeFrameRemoval: (doc) => terminate({
+              type: `intent-${intent._id}:exposeFrameRemoval`
             }),
             throw: error => terminate({
               type: `intent-${intent._id}:error`,

--- a/src/intents.js
+++ b/src/intents.js
@@ -21,7 +21,7 @@ const errorSerializer = (() => {
 })()
 
 // inject iframe for service in given element
-function injectService (url, element, intent, data) {
+function injectService (url, element, intent, data, onReadyCallback) {
   const document = element.ownerDocument
   if (!document) throw new Error('Cannot retrieve document object from given element')
 
@@ -29,6 +29,8 @@ function injectService (url, element, intent, data) {
   if (!window) throw new Error('Cannot retrieve window object from document')
 
   const iframe = document.createElement('iframe')
+  // if callback provided for when iframe is loaded
+  if (typeof onReadyCallback === 'function') iframe.onload = onReadyCallback
   iframe.setAttribute('src', url)
   iframe.classList.add(intentClass)
   element.appendChild(iframe)
@@ -108,7 +110,7 @@ export function create (cozy, action, type, data = {}, permissions = []) {
     }
   })
 
-  createPromise.start = (element) => {
+  createPromise.start = (element, onReadyCallback) => {
     return createPromise.then(intent => {
       let service = intent.attributes.services && intent.attributes.services[0]
 
@@ -116,7 +118,7 @@ export function create (cozy, action, type, data = {}, permissions = []) {
         return Promise.reject(new Error('Unable to find a service'))
       }
 
-      return injectService(service.href, element, intent, data)
+      return injectService(service.href, element, intent, data, onReadyCallback)
     })
   }
 

--- a/src/intents.js
+++ b/src/intents.js
@@ -204,7 +204,8 @@ export function createService (cozy, intentId, serviceWindow) {
               document: doc
             }),
             exposeFrameRemoval: (doc) => terminate({
-              type: `intent-${intent._id}:exposeFrameRemoval`
+              type: `intent-${intent._id}:exposeFrameRemoval`,
+              document: doc
             }),
             throw: error => terminate({
               type: `intent-${intent._id}:error`,

--- a/src/intents.js
+++ b/src/intents.js
@@ -199,14 +199,19 @@ export function createService (cozy, intentId, serviceWindow) {
           return {
             getData: () => data,
             getIntent: () => intent,
-            terminate: (doc) => terminate({
-              type: `intent-${intent._id}:done`,
-              document: doc
-            }),
-            exposeFrameRemoval: (doc) => terminate({
-              type: `intent-${intent._id}:exposeFrameRemoval`,
-              document: doc
-            }),
+            terminate: (doc) => {
+              if (data && data.exposeIntentFrameRemoval) {
+                return terminate({
+                  type: `intent-${intent._id}:exposeFrameRemoval`,
+                  document: doc
+                })
+              } else {
+                return terminate({
+                  type: `intent-${intent._id}:done`,
+                  document: doc
+                })
+              }
+            },
             throw: error => terminate({
               type: `intent-${intent._id}:error`,
               error: errorSerializer.serialize(error)

--- a/test/unit/intents.js
+++ b/test/unit/intents.js
@@ -124,12 +124,33 @@ describe('Intents', function () {
       const element = mockElement()
       const {documentMock, iframeMock} = element
 
+      const onReadyCallbackMock = () => {}
+
+      cozy.client.intents
+        .create('PICK', 'io.cozy.files')
+        .start(element, onReadyCallbackMock)
+
+      setTimeout(() => {
+        should(documentMock.createElement.withArgs('iframe').calledOnce).be.true()
+        should(iframeMock.onload).equal(onReadyCallbackMock)
+        should(iframeMock.setAttribute.withArgs('src', expectedIntent.attributes.services[0].href).calledOnce).be.true()
+        should(iframeMock.classList.add.withArgs('coz-intent').calledOnce).be.true()
+        should(element.appendChild.withArgs(iframeMock).calledOnce).be.true()
+        done()
+      }, 10)
+    })
+
+    it('should inject iframe (not async) also without onReadyCallback', function (done) {
+      const element = mockElement()
+      const {documentMock, iframeMock} = element
+
       cozy.client.intents
         .create('PICK', 'io.cozy.files')
         .start(element)
 
       setTimeout(() => {
         should(documentMock.createElement.withArgs('iframe').calledOnce).be.true()
+        should(iframeMock.onload).be.undefined()
         should(iframeMock.setAttribute.withArgs('src', expectedIntent.attributes.services[0].href).calledOnce).be.true()
         should(iframeMock.classList.add.withArgs('coz-intent').calledOnce).be.true()
         should(element.appendChild.withArgs(iframeMock).calledOnce).be.true()
@@ -345,6 +366,59 @@ describe('Intents', function () {
       }, 10)
 
       return call.should.be.fulfilledWith(result)
+    })
+
+    it('should handle intent exposeFrameRemoval', async function () {
+      const element = mockElement()
+      const {windowMock, iframeMock, iframeWindowMock} = element
+
+      const handshakeEventMessageMock = {
+        origin: serviceUrl,
+        data: {
+          type: 'intent-77bcc42c-0fd8-11e7-ac95-8f605f6e8338:ready'
+        },
+        source: iframeWindowMock
+      }
+
+      const docMock = {
+        id: 'abcde1234'
+      }
+
+      const resolveexposeFrameRemovalEventMessageMock = {
+        origin: serviceUrl,
+        data: {
+          type: 'intent-77bcc42c-0fd8-11e7-ac95-8f605f6e8338:exposeFrameRemoval',
+          document: docMock
+        },
+        source: iframeWindowMock
+      }
+
+      const call = cozy.client.intents
+        .create('PICK', 'io.cozy.files', {key: 'value'})
+        .start(element)
+
+      setTimeout(() => {
+        should(windowMock.addEventListener.withArgs('message').calledOnce).be.true()
+        should(windowMock.removeEventListener.neverCalledWith('message')).be.true()
+
+        const messageEventListener = windowMock.addEventListener.firstCall.args[1]
+
+        messageEventListener(handshakeEventMessageMock)
+        should(iframeWindowMock.postMessage.calledWithMatch({key: 'value'}, serviceUrl)).be.true()
+
+        messageEventListener(resolveexposeFrameRemovalEventMessageMock)
+        should(windowMock.removeEventListener.withArgs('message', messageEventListener).calledOnce).be.true()
+      }, 10)
+
+      return call.then(result => {
+        should(result.doc).equal(docMock)
+        should(result.removeIntentFrame).be.Function()
+
+        // test iframe removing by calling the returned closing method
+        should(iframeMock.parentNode.removeChild.withArgs(iframeMock).calledOnce).be.false()
+        result.removeIntentFrame()
+        should(iframeMock.parentNode.removeChild.withArgs(iframeMock).calledOnce).be.true()
+      })
     })
   })
 
@@ -718,6 +792,111 @@ describe('Intents', function () {
           const service = await cozy.client.intents.createService(expectedIntent._id, windowMock)
 
           service.cancel()
+
+          should.throws(() => {
+            service.terminate(result)
+          }, /Intent service has already been terminated/)
+        })
+      })
+
+      describe('exposeFrameRemoval', function () {
+        it('should send closing method to Client with result', async function () {
+          const windowMock = mockWindow()
+
+          const clientHandshakeEventMessageMock = {
+            origin: expectedIntent.attributes.client,
+            data: { foo: 'bar' }
+          }
+
+          const result = {
+            type: 'io.cozy.things'
+          }
+
+          windowMock.parent.postMessage.callsFake(() => {
+            const messageEventListener = windowMock.addEventListener.secondCall.args[1]
+            messageEventListener(clientHandshakeEventMessageMock)
+          })
+
+          const service = await cozy.client.intents.createService(expectedIntent._id, windowMock)
+
+          service.exposeFrameRemoval(result)
+
+          const messageMatch = sinon.match({
+            type: 'intent-77bcc42c-0fd8-11e7-ac95-8f605f6e8338:exposeFrameRemoval',
+            document: result
+          })
+
+          windowMock.parent.postMessage
+            .withArgs(messageMatch, expectedIntent.attributes.client).calledOnce.should.be.true()
+        })
+
+        it('should send closing method to Client also with no parameters', async function () {
+          global.window = mockWindow()
+
+          const clientHandshakeEventMessageMock = {
+            origin: expectedIntent.attributes.client,
+            data: { foo: 'bar' }
+          }
+
+          window.parent.postMessage.callsFake(() => {
+            const messageEventListener = window.addEventListener.secondCall.args[1]
+            messageEventListener(clientHandshakeEventMessageMock)
+          })
+
+          const service = await cozy.client.intents.createService(expectedIntent._id, window)
+
+          service.exposeFrameRemoval()
+
+          const messageMatch = sinon.match({type: 'intent-77bcc42c-0fd8-11e7-ac95-8f605f6e8338:exposeFrameRemoval'})
+
+          window.parent.postMessage
+            .withArgs(messageMatch, expectedIntent.attributes.client).calledOnce.should.be.true()
+
+          delete global.window
+        })
+
+        it('should not be called twice', async function () {
+          const windowMock = mockWindow()
+
+          const clientHandshakeEventMessageMock = {
+            origin: expectedIntent.attributes.client,
+            data: { foo: 'bar' }
+          }
+
+          windowMock.parent.postMessage.callsFake(() => {
+            const messageEventListener = windowMock.addEventListener.secondCall.args[1]
+            messageEventListener(clientHandshakeEventMessageMock)
+          })
+
+          const service = await cozy.client.intents.createService(expectedIntent._id, windowMock)
+
+          service.exposeFrameRemoval()
+
+          should.throws(() => {
+            service.exposeFrameRemoval()
+          }, /Intent service has already been terminated/)
+        })
+
+        it('should forbbid further calls to terminate()', async function () {
+          const windowMock = mockWindow()
+
+          const clientHandshakeEventMessageMock = {
+            origin: expectedIntent.attributes.client,
+            data: { foo: 'bar' }
+          }
+
+          const result = {
+            type: 'io.cozy.things'
+          }
+
+          windowMock.parent.postMessage.callsFake(() => {
+            const messageEventListener = windowMock.addEventListener.secondCall.args[1]
+            messageEventListener(clientHandshakeEventMessageMock)
+          })
+
+          const service = await cozy.client.intents.createService(expectedIntent._id, windowMock)
+
+          service.exposeFrameRemoval()
 
           should.throws(() => {
             service.terminate(result)


### PR DESCRIPTION
Two main points:

* Handle `exposeIntentFrameRemoval` data flag to terminate the service without removing the intent DOM node directly but by providing the removal function to the client
__Example of usage__: Claudy has an animated (CSS) menu closing. Using this feature it will be possible to terminate the intent `.then` listen the animation ending before removing the intent iframe node using the resolved `removeIntentFrame ` function (and avoiding a sudden blank view in the Claudy view)

* Add an `onReadyCallback` optional argument to the `create` method in order to allow providing a callback function to be run when the intent iframe will be loaded (iframe `onload` listener).
__Example of usage__: Claudy will now wait the intent iframe to be totally loaded before beginning its opening animation in order to keep having a fluid UX.

__Edit:__ Rename `exposeRemoving` to `exposeFrameRemoval` and use a data flag instead of a method