### PR TITLE
feat: option to allow bypassing credentials cache

### DIFF
--- a/src/auth_v3.js
+++ b/src/auth_v3.js
@@ -251,7 +251,7 @@ export function refreshToken (cozy, client, token) {
 
 // oauthFlow performs the stateful registration and access granting of an OAuth
 // client.
-export function oauthFlow (cozy, storage, clientParams, onRegistered) {
+export function oauthFlow (cozy, storage, clientParams, onRegistered, ignoreCachedCredentials = false) {
   let tryCount = 0
 
   function clearAndRetry (err) {
@@ -271,10 +271,14 @@ export function oauthFlow (cozy, storage, clientParams, onRegistered) {
       })
   }
 
-  return Promise.all([
-    storage.load(CredsKey),
-    storage.load(StateKey)
-  ])
+  const initialPromise = (ignoreCachedCredentials) ? storage.clear() : Promise.resolve()
+
+  return initialPromise.then(() => {
+    return Promise.all([
+      storage.load(CredsKey),
+      storage.load(StateKey)
+    ])
+  })
   .then(([credentials, storedState]) => {
     // If credentials are cached we re-fetch the registered client with the
     // said token. Fetching the client, if the token is outdated we should try

--- a/src/index.js
+++ b/src/index.js
@@ -206,7 +206,7 @@ class Client {
     }
   }
 
-  authorize () {
+  authorize (forceTokenRefresh = false) {
     const state = this._authstate
     if (state === AuthOK || state === AuthRunning) {
       return this._authcreds
@@ -222,7 +222,8 @@ class Client {
           this,
           this._storage,
           this._clientParams,
-          this._onRegistered
+          this._onRegistered,
+          forceTokenRefresh
         )
       }
       // we expect to be on a client side application running in a browser


### PR DESCRIPTION
We have a case where the `scope` that is being requested might be different from the one that is cached, but the oauth flow always use the cached version, so the new scope is never picked up.

I've added a flag to the `client.authorize()` method that explicitly tells the oauth flow to ignore the cache. It defaults to false so existing calls shouldn't be affected. Does that make sense? Is there a better way to accomplish this?