### PR TITLE
feat: Use sort=datetime when fetching referenced files

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -200,7 +200,6 @@ class Client {
 
     // Exposing cozyFetchJSON to make some development easier. Should be temporary.
     this.fetchJSON = function _fetchJSON () {
-      console.warn && console.warn('cozy.client.fetchJSON is a temporary method for development purpose, you should avoid using it.')
       const args = [this].concat(Array.prototype.slice.call(arguments))
       return cozyFetch.cozyFetchJSON.apply(this, args)
     }

--- a/src/relations.js
+++ b/src/relations.js
@@ -24,7 +24,8 @@ export function listReferencedFiles (cozy, doc) {
 export function fetchReferencedFiles (cozy, doc, options) {
   if (!doc) throw new Error('missing doc argument')
   const params = Object.keys(options).map(key => `&page[${key}]=${options[key]}`).join('')
-  return cozyFetchRawJSON(cozy, 'GET', `${makeReferencesPath(doc)}?include=files${params}`)
+  // As datetime is the only sort option available, I see no reason to not have it by default
+  return cozyFetchRawJSON(cozy, 'GET', `${makeReferencesPath(doc)}?include=files&sort=datetime${params}`)
 }
 
 function makeReferencesPath (doc) {


### PR DESCRIPTION
I also removed the annoying console.warn when using cozy.fetchJSON.