### PR TITLE
Adapt jobs.count and add queued method

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -99,7 +99,8 @@ const intentsProto = {
 
 const jobsProto = {
   create: jobs.create,
-  count: jobs.count
+  count: jobs.count,
+  queued: jobs.queued
 }
 
 const offlineProto = {

--- a/src/jobs.js
+++ b/src/jobs.js
@@ -2,7 +2,11 @@ import {cozyFetchJSON} from './fetch'
 
 export function count (cozy, workerType) {
   return cozyFetchJSON(cozy, 'GET', `/jobs/queue/${workerType}`)
-    .then(data => data.attributes.count)
+    .then(data => data.length)
+}
+
+export function queued (cozy, workerType) {
+  return cozyFetchJSON(cozy, 'GET', `/jobs/queue/${workerType}`)
 }
 
 export function create (cozy, workerType, args, options) {

--- a/test/integration/data.js
+++ b/test/integration/data.js
@@ -74,7 +74,7 @@ describe('data API', function () {
     })
 
     it('Works when the database does not exist yet', async function () {
-      const resultsById = await cozy.client.data.findMany('io.cozy.jobs', [missingID])
+      const resultsById = await cozy.client.data.findMany('io.cozy.idonotexist', [missingID])
       resultsById[missingID].error.status.should.equal(404)
     })
   })
@@ -97,7 +97,7 @@ describe('data API', function () {
     })
 
     it('Returns an empty array when the database does not exist yet', async function () {
-      const docs = await cozy.client.data.findAll('io.cozy.jobs')
+      const docs = await cozy.client.data.findAll('io.cozy.idonotexist')
       should(docs.length).equal(0)
     })
   })

--- a/test/integration/jobs.js
+++ b/test/integration/jobs.js
@@ -27,6 +27,11 @@ describe('jobs api', async function () {
     count.should.equal(0)
   })
 
+  it('gets the jobs in a queue', async function () {
+    const jobs = await cozy.client.jobs.queued('log')
+    jobs.length.should.equal(0)
+  })
+
   it('enqueues a job', async function () {
     const created = await cozy.client.jobs.create('log', { foo: 'bar' }, { timeout: 2 })
     created.should.have.property('_id')

--- a/test/testapp-manifest.json
+++ b/test/testapp-manifest.json
@@ -29,6 +29,10 @@
       "description": "Required for tests of cozy-client-js",
       "type": "io.cozy.testobject2"
     },
+    "idonotexist": {
+      "description": "Required for tests of cozy-client-js",
+      "type": "io.cozy.idonotexist"
+    },
     "testreferencer": {
       "description": "Required for tests of cozy-client-js",
       "type": "io.cozy.testreferencer"


### PR DESCRIPTION
The `/jobs/queue` API has been changed in the stack to actually return the jobs data. This PR adapt `cozy-client-js` to this change.