### PR TITLE
feat: allow to specify processJSONAPI in fetchJSON options ✨

### DIFF
--- a/src/fetch.js
+++ b/src/fetch.js
@@ -49,8 +49,9 @@ function cozyFetchWithAuth (cozy, fullpath, options, credentials) {
 }
 
 export function cozyFetchJSON (cozy, method, path, body, options = {}) {
+  const processJSONAPI = typeof options.processJSONAPI === 'undefined' || options.processJSONAPI
   return fetchJSON(cozy, method, path, body, options)
-    .then(handleJSONResponse)
+    .then(response => handleJSONResponse(response, processJSONAPI))
 }
 
 export function cozyFetchRawJSON (cozy, method, path, body, options = {}) {


### PR DESCRIPTION
If a response from stack has a `data` attribute, `handleJSONResponse` will return directly the content of data (see https://github.com/cozy/cozy-client-js/blob/master/src/jsonapi.js#L41).

In https://github.com/cozy/cozy-collect/pull/343, for retrieving jobs with new route https://github.com/cozy/cozy-stack/blob/master/docs/jobs.md#get-jobstriggersjobs, we need to be able to get the full raw response and not only the content of the `data` attribute.

This PR allow to pass a new `processJSONAPI` option to fetchJSON to bypass the default behavior and get the full raw response.