### PR TITLE
feat: sanitize file name 🚑

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - none yet
 
 ### Added
-- none yet
+- Now trim file name before any creation or update.
 
 ### Removed
 - none yet


### PR DESCRIPTION
Having a trailing space in a Transifex translation, we ended up with a space in our file name, which was causing an error on Windows.