### PR TITLE
feat: add support for heic and heif files

### DIFF
--- a/src/files.js
+++ b/src/files.js
@@ -13,6 +13,12 @@ function sanitizeFileName (name) {
   return name && name.trim()
 }
 
+function getFileTypeFromName (name) {
+  if (/\.heic$/.test(name)) return 'image/heic'
+  else if (/\.heif$/.test(name)) return 'image/heif'
+  else return null
+}
+
 function doUpload (cozy, data, method, path, options) {
   if (!data) {
     throw new Error('missing data argument')
@@ -38,7 +44,7 @@ function doUpload (cozy, data, method, path, options) {
     if (isBuffer) {
       contentType = contentTypeOctetStream
     } else if (isFile) {
-      contentType = data.type || contentTypeOctetStream
+      contentType = data.type || getFileTypeFromName(data.name) || contentTypeOctetStream
       if (!lastModifiedDate) {
         lastModifiedDate = data.lastModifiedDate
       }


### PR DESCRIPTION
On older devices, the OS doesn't compute a `type` for `HEIC` and `HEIF` files, so I added a manual check as a fallback option.