### PR TITLE
fix: BREAKING CHANGE detect expired token and reload page

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -199,6 +199,8 @@ class Client {
 
     this._url = url
 
+    this._invalidTokenErrorHandler = options.onInvalidTokenError !== undefined ? options.onInvalidTokenError : cozyFetch.handleInvalidTokenError
+
     const disablePromises = !!options.disablePromises
     addToProto(this, this.data, dataProto, disablePromises)
     addToProto(this, this.auth, authProto, disablePromises)


### PR DESCRIPTION
There are weird situations where the app's cookie doesn't match the actual session cookie. When that happens, all XHR calls will fail until the cookie is fixed. The proper way to fix the cookie is to reload the page with a `?disconnect=1` parameter.

I've done this, but since the change is at such a low level, this will impact every app that uses cozy-client-js. Which is probably what we want.

The redirection only happens if we're actually on an app page in a browser. So if you're in node.js, or on `file://whatever` in a cordova or electron app, this change shouldn't affect you at all.
If, for some reason, you don't want the page reload, or want to handle the error yourself, you can supply a new option to `cozy.client.init`. `onInvalidTokenError` can be a function, or it can be `false`/`null` to do nothing at all.
