### PR TITLE
feat: add intents.redirect() method ✨

### DIFF
--- a/docs/intents-api.md
+++ b/docs/intents-api.md
@@ -88,3 +88,21 @@ cozy.client.intents.createService('77bcc42c-0fd8-11e7-ac95-8f605f6e8338', window
     intentService.terminate(resultingDoc)
   })
 ```
+
+### `cozy.client.intents.getRedirectionURL()`
+
+`cozy.client.intents.getRedirectionURL(doctype, data)` retrieves a redirection URL for a given doctype, with specified data. It relies internally on a regular intent mechanism, which creates an intent for the `REDIRECT` action. It then build the redirection URL from URL sent by the stack and returns it. This URL can be used as link `href` for example, to show the doctype or the document in an application able to handle it.
+
+#### Example
+```jsx
+  const myFolder = {
+    folder: '4bce4649-e7b7-4226-d82e-6b87dbb684e7'
+  }
+
+  const url = await cozy.client.getRedirectionURL('io.cozy.files', myFolder)
+  // url is http://domain-app.cozy.rocks/#/files?folder=4bce4649-e7b7-4226-d82e-6b87dbb684e7
+```
+
+### `cozy.client.intents.redirect()`
+
+`cozy.client.intents.redirect(doctype, data)` is based on `cozy.client.intents.getRedirectionURL()` and it redirects the browser to the retrieved URL.

--- a/src/index.js
+++ b/src/index.js
@@ -93,7 +93,9 @@ const filesProto = {
 
 const intentsProto = {
   create: intents.create,
-  createService: intents.createService
+  createService: intents.createService,
+  getRedirectionURL: intents.getRedirectionURL,
+  redirect: intents.redirect
 }
 
 const jobsProto = {

--- a/src/intents.js
+++ b/src/intents.js
@@ -238,3 +238,43 @@ export function createService (cozy, intentId, serviceWindow) {
         })
     })
 }
+
+// Redirect to an app able to handle the doctype
+// Redirections are more or less a hack of the intent API to retrieve an URL for
+// accessing a given doctype or a given document.
+// It needs to use a special action `REDIRECT`
+export async function getRedirectionURL (cozy, type, data) {
+  if (!type && !data) throw new Error(`Cannot retrieve redirection, at least type or doc must be provided`)
+
+  const intent = await create(cozy, 'REDIRECT', type, data)
+
+  const service = pickService(intent)
+  if (!service) throw new Error('Unable to find a service')
+
+  // Intents cannot be deleted now
+  // await deleteIntent(cozy, intent)
+
+  // ignore query string and intent id
+  const baseURL = service.href.split('?')[0]
+  // FIXME: Handle the fact that the stack encode the '#' character in the URL
+  const sanitizedURL = baseURL.replace('%23', '#')
+  return data ? buildRedirectionURL(sanitizedURL, data) : sanitizedURL
+}
+
+function isSerializable (value) {
+  return !['object', 'function'].includes(typeof value)
+}
+
+function buildRedirectionURL (url, data) {
+  const parameterStrings = Object.keys(data)
+    .filter(key => isSerializable(data[key]))
+    .map(key => `${key}=${data[key]}`)
+
+  return parameterStrings.length ? `${url}?${parameterStrings.join('&')}` : url
+}
+
+export async function redirect (cozy, type, doc) {
+  if (!window) throw new Error('redirect() method can only be called in a browser')
+  const redirectionURL = await getRedirectionURL(cozy, type, doc)
+  window.location.href = redirectionURL
+}

--- a/src/intents.js
+++ b/src/intents.js
@@ -108,6 +108,16 @@ function injectService (url, element, intent, data, onReadyCallback) {
 }
 
 const first = arr => arr && arr[0]
+// In a far future, the user will have to pick the desired service from a list.
+// For now it's our job, an easy job as we arbitrary pick the first service of
+// the list.
+function pickService (intent, filterServices) {
+  const services = intent.attributes.services
+  const filteredServices = filterServices
+    ? (services || []).filter(filterServices)
+    : services
+  return first(filteredServices)
+}
 
 export function create (cozy, action, type, data = {}, permissions = []) {
   if (!action) throw new Error(`Misformed intent, "action" property must be provided`)
@@ -127,15 +137,9 @@ export function create (cozy, action, type, data = {}, permissions = []) {
 
   createPromise.start = (element, onReadyCallback) => {
     return createPromise.then(intent => {
-      const filterServices = data.filterServices
+      const service = pickService(intent, data.filterServices)
       const restData = Object.assign({}, data)
       delete restData.filterServices
-
-      const services = intent.attributes.services
-      const filteredServices = filterServices
-        ? (services || []).filter(filterServices)
-        : services
-      const service = first(filteredServices)
 
       if (!service) {
         return Promise.reject(new Error('Unable to find a service'))

--- a/test/mock-api.js
+++ b/test/mock-api.js
@@ -717,6 +717,37 @@ const ROUTES = [
       }
     }
   }, {
+    name: 'CreateIntentToRedirect',
+    method: 'POST',
+    matcher: /intents/,
+    response: {
+      headers: {
+        'content-type': 'application/vnd.api+json'
+      },
+      body: {
+        data: {
+          id: '77bcc42c-0fd8-11e7-ac95-8f605f6e8338',
+          type: 'io.cozy.intents',
+          attributes: {
+            action: 'REDIRECT',
+            type: 'io.cozy.files',
+            permissions: ['GET'],
+            client: 'store.cozy.example.net',
+            services: [
+              {
+                slug: 'store',
+                href: 'https://drive.cozy.example.net/%23/files/?intent=77bcc42c-0fd8-11e7-ac95-8f605f6e8338'
+              }
+            ]
+          },
+          links: {
+            self: '/intents/77bcc42c-0fd8-11e7-ac95-8f605f6e8338',
+            permissions: '/permissions/a340d5e0-d647-11e6-b66c-5fc9ce1e17c6'
+          }
+        }
+      }
+    }
+  }, {
     name: 'GetIntent',
     method: 'GET',
     matcher: /intents/,

--- a/test/unit/intents.js
+++ b/test/unit/intents.js
@@ -111,14 +111,14 @@ describe('Intents', function () {
       it('should filter intents', () => {
         cozy.client.intents
           .create('EDIT', 'io.cozy.files', {
-            filterServices: x => x.slug == 'files'
+            filterServices: x => x.slug === 'files'
           })
           .should.not.be.rejectedWith(/Unable to find a service/)
       })
       it('should filter intents', () => {
         cozy.client.intents
           .create('EDIT', 'io.cozy.files', {
-            filterServices: x => x.slug == 'files2'
+            filterServices: x => x.slug === 'files2'
           })
           .should.be.rejectedWith(/Unable to find a service/)
       })
@@ -968,6 +968,35 @@ describe('Intents', function () {
             service.terminate(result)
           }, /Intent service has already been terminated/)
         })
+      })
+    })
+  })
+
+  describe('getRedirectionURL', () => {
+    describe('to doctype', () => {
+      beforeEach(mock.mockAPI('CreateIntentToRedirect'))
+
+      it('returns expected URL for doctype', async () => {
+        return cozy.client.intents.getRedirectionURL('io.cozy.files')
+          .then(url => {
+            should.equal(url, 'https://drive.cozy.example.net/#/files/')
+          })
+      })
+
+      it('returns expected URL for document', async () => {
+        const data = {
+          id: 'da20344a-e37f-440a-a98f-7efa73671b95',
+          folder: 'a093723b-0e70-4050-9121-10394b53b966',
+          ignoredFunction: (foo) => `${foo}bar`,
+          ignoredObject: {
+            attribute: 'value'
+          },
+          ignoredArray: ['value1', 'value2']
+        }
+        return cozy.client.intents.getRedirectionURL('io.cozy.files', data)
+          .then(url => {
+            should.equal(url, 'https://drive.cozy.example.net/#/files/?id=da20344a-e37f-440a-a98f-7efa73671b95&folder=a093723b-0e70-4050-9121-10394b53b966')
+          })
       })
     })
   })


### PR DESCRIPTION
~PRIORITY : VERY LOW~

This PR tries to solve the redirection point exposed in #201 and adds two methods to intents API, both used to easily redirect to a given document or a given doctype. The two added methods are:

* `getRedirectionURL(type, data)` which retrieves a redirection URL.
* `redirect(type, data)` which retrieves a redirection URL and performs the redirection.

### Example

```jsx
import Button from 'cozy-ui/react/Button'
// [...]
  render() {
    const { folder } = this.props
    return (
      <Button
        label={`Open ${folder.name}`}
        onClick={() => cozy.client.intents.redirect('io.cozy.files', folder)}
      />
    )
  }
```

### Declaring a redirection handler

Redirection are declared in `manfiest.webapp`, like a regular intent

```json
"intents": [
    {
      "action": "REDIRECT",
      "type": [
        "io.cozy.konnectors"
      ],
      "href": "/"
    }
  ],
```

### Current limitations
* For now, it is still not possible to remove an intent from database.
* Statck cannot handle an intent having a sharp character in this `href` attribute, and URLencode it (i.e. replaces `#` by `%23`).


