### PR TITLE
chore: declare iso fetch as dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "eslint-loader": "^2.0.0",
     "eslint-plugin-react": "^7.7.0",
     "fetch-mock": "5.5.0",
-    "isomorphic-fetch": "2.2.1",
     "mocha": "3.1.2",
     "mocha-webpack": "0.7.0",
     "npm-run-all": "^4.0.2",
@@ -78,6 +77,7 @@
   },
   "dependencies": {
     "core-js": "^2.5.3",
+    "isomorphic-fetch": "^2.2.1",
     "pouchdb": "6.1.1",
     "pouchdb-adapter-cordova-sqlite": "https://github.com/SnceGroup/pouchdb-adapter-cordova-sqlite.git#f3ee23009b70209c611435d57491aa77fb88802a",
     "pouchdb-find": "0.10.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3157,7 +3157,7 @@ isobject@^2.0.0:
   dependencies:
     isarray "1.0.0"
 
-isomorphic-fetch@2.2.1, isomorphic-fetch@^2.1.1:
+isomorphic-fetch@^2.1.1, isomorphic-fetch@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz#611ae1acf14f5e81f729507472819fe9733558a9"
   dependencies:


### PR DESCRIPTION
`isomorphic-fetch` is an actual dependency for node, so it can't be in `devDependency` or it won't get installed.