### PR TITLE
fix: scopes is in clientParams

### DIFF
--- a/docs/intro.md
+++ b/docs/intro.md
@@ -124,8 +124,12 @@ cozy.client.init({
   disablePromises: false,
   version: 3,
   oauth: {
-    clientParams: {/*...*/},
-    scopes: ["io.cozy.files:GET"],
+    clientParams: {
+      redirectURI: 'http://localhost:3333/oauth/callback',
+      softwareID: 'cozy-client-js',
+      clientName: 'example',
+      scopes: ["io.cozy.files:GET"]
+    },
     onRegistered: (client, url) => { /* */ },
     storage: new cozy.auth.LocalStorage(window.localStorage)
   }


### PR DESCRIPTION
`scopes` was outside of `clientParams`, it should be inside.

See tests : https://github.com/cozy/cozy-client-js/blob/b0fd96f7c8c545dd0b6df610b839e752435471e0/test/integration/auth.js#L21-L32

Thanks to Schoumi for spotting the error !