### PR TITLE
feat(intents): add an redirectFn parameter to redirect method

### DIFF
--- a/src/intents/index.js
+++ b/src/intents/index.js
@@ -79,9 +79,13 @@ function buildRedirectionURL(url, data) {
   return parameterStrings.length ? `${url}?${parameterStrings.join('&')}` : url
 }
 
-export async function redirect(cozy, type, doc) {
+export async function redirect(cozy, type, doc, redirectFn) {
   if (!window)
     throw new Error('redirect() method can only be called in a browser')
   const redirectionURL = await getRedirectionURL(cozy, type, doc)
+  if (redirectFn && typeof redirectFn === 'function') {
+    return redirectFn(redirectionURL)
+  }
+
   window.location.href = redirectionURL
 }


### PR DESCRIPTION
This adds a `redirectFn` so we can pass a custom redirection function when we call `cozy.client.intents.redirect`.

This enables us to use an inapp browser and redirect the user using intents redirect on mobile apps, for example.