### PR TITLE
Properly compute intents base URL with hash

### DIFF
--- a/src/intents/index.js
+++ b/src/intents/index.js
@@ -42,6 +42,10 @@ export function createService(cozy, intentId, serviceWindow) {
   return service.start(cozy, intentId, serviceWindow)
 }
 
+function removeQueryString(url) {
+  return url.replace(/\?[^/#]*/, '')
+}
+
 // Redirect to an app able to handle the doctype
 // Redirections are more or less a hack of the intent API to retrieve an URL for
 // accessing a given doctype or a given document.
@@ -60,11 +64,8 @@ export async function getRedirectionURL(cozy, type, data) {
   // Intents cannot be deleted now
   // await deleteIntent(cozy, intent)
 
-  // ignore query string and intent id
-  const baseURL = service.href.split('?')[0]
-  // FIXME: Handle the fact that the stack encode the '#' character in the URL
-  const sanitizedURL = baseURL.replace('%23', '#')
-  return data ? buildRedirectionURL(sanitizedURL, data) : sanitizedURL
+  const baseURL = removeQueryString(service.href)
+  return data ? buildRedirectionURL(baseURL, data) : baseURL
 }
 
 function isSerializable(value) {

--- a/test/mock-api.js
+++ b/test/mock-api.js
@@ -788,7 +788,7 @@ const ROUTES = [
               {
                 slug: 'store',
                 href:
-                  'https://drive.cozy.example.net/%23/files/?intent=77bcc42c-0fd8-11e7-ac95-8f605f6e8338'
+                  'https://drive.cozy.example.net/?intent=77bcc42c-0fd8-11e7-ac95-8f605f6e8338#/files'
               }
             ]
           },

--- a/test/unit/intents.js
+++ b/test/unit/intents.js
@@ -985,7 +985,11 @@ describe('Intents', function() {
             windowMock
           )
 
-          service.compose('ACTION', 'io.cozy.doctype', { key: 'value' })
+          service.compose(
+            'ACTION',
+            'io.cozy.doctype',
+            { key: 'value' }
+          )
 
           const messageMatch = sinon.match({
             action: 'ACTION',
@@ -1034,7 +1038,11 @@ describe('Intents', function() {
           })
 
           return service
-            .compose('ACTION', 'io.cozy.doctype', { key: 'value' })
+            .compose(
+              'ACTION',
+              'io.cozy.doctype',
+              { key: 'value' }
+            )
             .should.be.fulfilledWith(result)
         })
       })
@@ -1402,7 +1410,7 @@ describe('Intents', function() {
         return cozy.client.intents
           .getRedirectionURL('io.cozy.files')
           .then(url => {
-            should.equal(url, 'https://drive.cozy.example.net/#/files/')
+            should.equal(url, 'https://drive.cozy.example.net/#/files')
           })
       })
 
@@ -1416,14 +1424,14 @@ describe('Intents', function() {
           },
           ignoredArray: ['value1', 'value2']
         }
-        return cozy.client.intents
-          .getRedirectionURL('io.cozy.files', data)
-          .then(url => {
-            should.equal(
-              url,
-              'https://drive.cozy.example.net/#/files/?id=da20344a-e37f-440a-a98f-7efa73671b95&folder=a093723b-0e70-4050-9121-10394b53b966'
-            )
-          })
+        const url1 = await cozy.client.intents.getRedirectionURL(
+          'io.cozy.files',
+          data
+        )
+        should.equal(
+          url1,
+          'https://drive.cozy.example.net/#/files?id=da20344a-e37f-440a-a98f-7efa73671b95&folder=a093723b-0e70-4050-9121-10394b53b966'
+        )
       })
     })
   })


### PR DESCRIPTION
The hash part is now provided at the end of the `href` by the stack, ccjs was skipping it then. Now it's handled properly.