### PR TITLE
Add the possibility to use cursor-based pagination for references

### DIFF
--- a/docs/files-api.md
+++ b/docs/files-api.md
@@ -336,28 +336,46 @@ const href = await cozy.client.files.getArchiveLinkByIds(["1592673"], "secretpro
 ### `cozy.client.data.addReferencedFiles(doc, fileIds)`
 
 `cozy.client.data.addReferencedFiles(doc, fileIds)` binds the files to the document.
-(see cozy-stack [documentation](https://cozy.github.io/cozy-stack/references-docs-in-vfs.html) for more details)
+(see cozy-stack [documentation](https://docs.cozy.io/en/cozy-stack/references-docs-in-vfs/) for more details)
 
 
 ### `cozy.client.data.removeReferencedFiles(doc, fileIds)`
 
 `cozy.client.data.removeReferencedFiles(doc, fileIds)` unbinds the files to the document.
-(see cozy-stack [documentation](https://cozy.github.io/cozy-stack/references-docs-in-vfs.html) for more details)
+(see cozy-stack [documentation](https://docs.cozy.io/en/cozy-stack/references-docs-in-vfs/) for more details)
 
 
 ### `cozy.client.data.listReferencedFiles(doc)`
 
 `cozy.client.data.listReferencedFiles(doc)` list the files bound to the document.
-(see cozy-stack [documentation](https://cozy.github.io/cozy-stack/references-docs-in-vfs.html) for more details).
+(see cozy-stack [documentation](https://docs.cozy.io/en/cozy-stack/references-docs-in-vfs/) for more details).
 
 It returns a promise for a list of filesIds. Files must then be fetched separately.
 
-### `cozy.client.data.fetchReferencedFiles(doc)`
+### `cozy.client.data.fetchReferencedFiles(doc, options, sort)`
 
-`cozy.client.data.fetchReferencedFiles(doc)` fetches the files bound to the document.
-(see cozy-stack [documentation](https://cozy.github.io/cozy-stack/references-docs-in-vfs.html) for more details).
+`cozy.client.data.fetchReferencedFiles(doc, options, sort)` fetches the files bound to the document.
+(see cozy-stack [documentation](https://docs.cozy.io/en/cozy-stack/references-docs-in-vfs/) for more details).
 
 It returns a promise for a list of files.
+
+There are 2 alternatives for pagination, that can be used through the `option` parameter: `cursor` and `skip`. For more details, see how the stack handles [pagination](https://docs.cozy.io/en/cozy-stack/jsonapi/#pagination). Note that cursor-based pagination performs way better than skip-based on large volumes.
+
+* `option` is an object with the following fields:
+  * `cursor` (recommended): specify the view's key and the starting docid. The starting docid can be empty for the first query and take the last returned docid for the next ones.
+  * `skip` (not recommended): ignore the first x results for pagination.
+  * `limit`: maximum number of results.
+* `sort` is a string which can be `datetime` (default) or `id`.
+
+```javascript
+const key = [DOCTYPE_ALBUMS, album._id]
+const cursor = [key, startDocid]
+const result = await cozyClient.data.fetchReferencedFiles(
+  album,
+  { cursor },
+  'id'
+)
+```
 
 ### `cozy.client.files.query(indexReference, query)`
 

--- a/docs/files-api.md
+++ b/docs/files-api.md
@@ -365,7 +365,7 @@ There are 2 alternatives for pagination, that can be used through the `option` p
   * `cursor` (recommended): specify the view's key and the starting docid. The starting docid can be empty for the first query and take the last returned docid for the next ones.
   * `skip` (not recommended): ignore the first x results for pagination.
   * `limit`: maximum number of results.
-* `sort` is a string which can be `datetime` (default) or `id`.
+* `sort` is a string which can be `datetime` (default) or `id`. *Warning:*  `datetime` is not compatible with cursor-based pagination. 
 
 ```javascript
 const key = [DOCTYPE_ALBUMS, album._id]

--- a/src/relations.js
+++ b/src/relations.js
@@ -22,16 +22,22 @@ export function listReferencedFiles(cozy, doc) {
   )
 }
 
-export function fetchReferencedFiles(cozy, doc, options) {
+export function fetchReferencedFiles(cozy, doc, options, sort) {
   if (!doc) throw new Error('missing doc argument')
   const params = Object.keys(options)
-    .map(key => `&page[${key}]=${options[key]}`)
+    .map(key => {
+      const value = encodeURIComponent(JSON.stringify(options[key]))
+      return `&page[${key}]=${value}`
+    })
     .join('')
-  // As datetime is the only sort option available, I see no reason to not have it by default
+  // Datetime is the default sort, but 'id' is also available
+  if (!sort) {
+    sort = 'datetime'
+  }
   return cozyFetchRawJSON(
     cozy,
     'GET',
-    `${makeReferencesPath(doc)}?include=files&sort=datetime${params}`
+    `${makeReferencesPath(doc)}?include=files&sort=${sort}${params}`
   )
 }
 


### PR DESCRIPTION
The recommended way to paginate view results in [CouchDB](https://docs.couchdb.org/en/stable/ddocs/views/pagination.html#paging-alternate-method), and therefore the stack, is through [cursors](https://docs.cozy.io/en/cozy-stack/jsonapi/#pagination).
This is because `skip` performs badly on large data collections, as it requires to scan the full B-Tree. 

For instance, a query on 2500 documents, with a limit of 100 docs per request, was taking more than 25s overall, with sometimes more than 1s per paginated request.

In `fetchReferencedFiles`, the sort was forced on `datetime`, which, behind the hoods, triggers the use of the `referenced-by-sorted-by-datetime` view (see [here](https://github.com/cozy/cozy-stack/blob/4e8da5cc1e5401ea43029de6d90bf248fac82405/web/files/references.go#L77-L81 ) and [here](https://github.com/cozy/cozy-stack/blob/ba71942b33a006d6b6a6bdfa39626292f27be5c5/pkg/couchdb/index.go#L71-L84))
This view uses  `[doctype, id, datetime]` keys, which is useful to get all the references sorted on the datetime through partial match queries on the key, e.g. `key=[io.cozy.photos.albums, "album-id", {}]`. However, it is not possible to use partial-match queries with cursor-based pagination as it requires the use of a `startkey_docid` field, which makes only sense when there are multiple results for a single key, not multiple ones.

So, this PR allows to use an `id` sort, which queries the `referenced-by` view, with `[doctype, id]` keys. Therefore, one can query a particular album with `key=[io.cozy.photos.albums, "album-id"]` and paginate the results with cursors through `startkey_docid`.

