### PR TITLE
 Merge pull request #290 from cozy-client-js/no-sanitize-filename-option

### DIFF
--- a/docs/files-api.md
+++ b/docs/files-api.md
@@ -13,6 +13,7 @@ It returns a promise for the document of the file created.
   * `contentType`: specify the content type of the uploaded data. For a `File` type, it is handled automatically in browsers (default: `application/octet-stream`). For nodejs, you can rely on an external module like [mime](https://github.com/broofa/node-mime)
   * `checksum`: the base64-encoded (with padding) MD5 digest of the file (optional).
   * `lastModifiedDate`: a date to specify the last modification time to use for the uploaded file. If the given `data` is a `File` instance, the `lastModifiedDate` is automatically used (not overridden).
+  * `noSanitize`: by default, the filename is sanitized to remove trailing whitespace; this option disables it.
 
 **Warning**: this API is not v2 compatible.
 

--- a/src/files.js
+++ b/src/files.js
@@ -91,14 +91,16 @@ function doUpload(cozy, data, method, path, options) {
 }
 
 export function create(cozy, data, options) {
-  let { name, dirID, executable } = options || {}
+  let { name, dirID, executable, noSanitize } = options || {}
 
   // handle case where data is a file and contains the name
   if (!name && typeof data.name === 'string') {
     name = data.name
   }
 
-  name = sanitizeFileName(name)
+  if (!noSanitize) {
+    name = sanitizeFileName(name)
+  }
 
   if (typeof name !== 'string' || name === '') {
     throw new Error('missing name argument')


### PR DESCRIPTION
It is useful for the cozy-desktop client as we want to have exactly the
same filenames on the client and on the cozy instance.

This is an up-to-date version of https://github.com/cozy/cozy-client-js/pull/281