### PR TITLE
feat: allow to add sourceAccount and sourceAccountIdentifer in cozyMetadata while uploading a file

### DIFF
--- a/docs/files-api.md
+++ b/docs/files-api.md
@@ -15,6 +15,9 @@ It returns a promise for the document of the file created.
   * `lastModifiedDate`: a date to specify the last modification time to use for the uploaded file. If the given `data` is a `File` instance, the `lastModifiedDate` is automatically used (not overridden).
   * `noSanitize`: by default, the filename is sanitized to remove trailing whitespace; this option disables it.
   * `metadata`: (object) metadata associated to the file
+  * `sourceAccount`: (string) allow to associate the file with the given account id in cozyMetadata
+  * `sourceAccountIdentifier`: (string) allow to associate the file with the given account
+    identifier (mostly the user login in the account) in cozyMetadata
 
 **Warning**: this API is not v2 compatible.
 

--- a/src/files.js
+++ b/src/files.js
@@ -46,7 +46,9 @@ async function doUpload(cozy, data, method, path, options) {
     checksum,
     lastModifiedDate,
     ifMatch,
-    metadata
+    metadata,
+    sourceAccount,
+    sourceAccountIdentifier
   } = options || {}
   if (!contentType) {
     if (isBuffer) {
@@ -84,10 +86,20 @@ async function doUpload(cozy, data, method, path, options) {
   if (metadata) {
     const metadataId = await sendMetadata(cozy, metadata)
     if (metadataId) {
-      finalpath += `${
-        finalpath.includes('?') ? '&' : '?'
-      }MetadataID=${metadataId}`
+      finalpath = addQuerystringParam(finalpath, 'MetadataID', metadataId)
     }
+  }
+
+  if (sourceAccount) {
+    finalpath = addQuerystringParam(finalpath, 'SourceAccount', sourceAccount)
+  }
+
+  if (sourceAccountIdentifier) {
+    finalpath = addQuerystringParam(
+      finalpath,
+      'SourceAccountIdentifier',
+      sourceAccountIdentifier
+    )
   }
 
   return cozyFetch(cozy, finalpath, {
@@ -471,4 +483,8 @@ function sortFiles(allFiles) {
   const sort = files =>
     files.sort((a, b) => a.attributes.name.localeCompare(b.attributes.name))
   return sort(folders).concat(sort(files))
+}
+
+function addQuerystringParam(path, key, value) {
+  return path + `${path}${finalpath.includes('?') ? '&' : '?'}${key}=${value}`
 }


### PR DESCRIPTION
sourceAccount is the io.cozy.accounts account id associated to the connector which uploaded the file
sourceAccountIdentifier is the user identifier (login most of the time) associated to the account