### PR TITLE
fix: Use global fetch instead of closure

### DIFF
--- a/src/offline.js
+++ b/src/offline.js
@@ -1,3 +1,6 @@
+// Define global `fetch` so it's made available to `pouchdb-browser`
+import 'isomorphic-fetch'
+
 import { DOCTYPE_FILES } from './doctypes'
 import { refreshToken } from './auth_v3'
 import { isOffline } from './utils'

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -52,8 +52,7 @@ if (NODE_TARGET === 'node') {
   config.externals = [nodeExternals()]
   config.plugins = [
     new webpack.ProvidePlugin({
-      btoa: 'btoa',
-      fetch: 'isomorphic-fetch'
+      btoa: 'btoa'
     }),
     new webpack.EnvironmentPlugin(Object.keys(process.env))
   ]


### PR DESCRIPTION
  Cozy Desktop uses `cozy-client-js` to interact with the user's Cozy
  and needs to be able to operate behind a proxy as well as define a
  custom User-Agent per user so support can follow their requests on the
  server.
  Electron offers better support for proxy configuration than Node so
  Cozy Desktop uses `electron-fetch` instead of `isomorphic-fetch` and
  `electron-proxy-agent` to customize the request's Agent with the proxy
  configuration.
  This means that Cozy Desktop needs to be able to replace the `fetch`
  method called by `cozy-client-js` as well so all requests made to the
  server use this custom configuration.
  The webpack's `providePlugin` plugin creates a closure with the given
  module around all modules calling the specified method. In our case,
  every module of `cozy-client-js` calling `fetch` will be wrapped in a
  closure binding `fetch` to the `isomorphic-fetch` imported by
  `cozy-client-js`. This renders overwritting it completely impossible
  for Cozy Desktop and thus prevents Cozy Desktop from upgrading
  `cozy-client-js` past version `0.15.0` since the change was introduced
  in version `0.15.1`.

  The proposed solution here is to import `isomorphic-fetch` which
  defines the global `fetch` variable in every `cozy-client-js` module
  who needs it, like the `offline` module which doesn't make a direct
  use of `fetch` but imports `pouchdb-browser` who needs `fetch` to be
  defined by the importing module or projet.