### PR TITLE
fix: Use go modules to fetch and build cozy-stack

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ services:
 env:
   global:
   - GOPATH=${TRAVIS_BUILD_DIR}/_workspace
+  - GO111MODULE=on
   - COZY_V3_DOMAIN="localhost:8080"
   - COZY_V3_PASSPHRASE="CozyTest_1"
 cache:
@@ -16,7 +17,7 @@ before_script:
 - docker run -d -p 5984:5984 --name couch apache/couchdb:2.3
 - eval "$(gimme 1.12)"
 - mkdir $GOPATH
-- go get -u github.com/cozy/cozy-stack
+- go get github.com/cozy/cozy-stack
 - go get -u github.com/rif/spark
 - curl -X PUT http://127.0.0.1:5984/{_users,_replicator,_global_changes}
 - $GOPATH/bin/cozy-stack serve &

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ before_script:
 - curl -X PUT http://127.0.0.1:5984/{_users,_replicator,_global_changes}
 - $GOPATH/bin/cozy-stack serve &
 - sleep 1
-- $GOPATH/bin/cozy-stack instances add --dev --passphrase "$COZY_V3_PASSPHRASE" "$COZY_V3_DOMAIN"
+- $GOPATH/bin/cozy-stack instances add --passphrase "$COZY_V3_PASSPHRASE" "$COZY_V3_DOMAIN"
 - export NAME=client-js
 - export TOKEN=apptoken
 - $TRAVIS_BUILD_DIR/test/testapp-git-daemon.sh /tmp/testapp $TRAVIS_BUILD_DIR/test/testapp-manifest.json


### PR DESCRIPTION
  `cozy-stack` has switched to go modules which requires us to use the
  `GO111MODULE=on` env variable when running `go get` to fetch and build
  `cozy-stack`.
  Besides, `cozy-stack` has a dependency to `github.com/robfig/cron/v3`
  which is not completely compatible with go modules (i.e. the `v3`
  part) and prevents us from running `go get -u`.