### PR TITLE
docs: Add a deprecated notice in the TOC

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,39 +4,25 @@
 
 ⚠️ This is the documentation for the old version of cozy-client. [Go to the new version](http://github.com/cozy/cozy-client) ✅.
 
+# [Cozy][cozy] Javascript Client
 
-[Cozy][cozy] Javascript Client
-==============================
-
-
-What's Cozy?
-------------
+## What's Cozy?
 
 ![Cozy Logo](https://cdn.rawgit.com/cozy/cozy-guidelines/master/templates/cozy_logo_small.svg)
 
-[Cozy][cozy] is a platform that brings all your web services in the same private space.  With it, your webapps and your devices can share data easily, providing you with a new experience. You can install Cozy on your own hardware where no one's tracking you.
+[Cozy][cozy] is a platform that brings all your web services in the same private space. With it, your webapps and your devices can share data easily, providing you with a new experience. You can install Cozy on your own hardware where no one's tracking you.
 
-
-What's cozy-client-js?
-------------------
+## What's cozy-client-js?
 
 `cozy-client-js` is a javascript library made by Cozy. It enables applications (client-side apps, konnectors, OAuth apps, etc.) to make requests to the cozy stack.
 
 If you are getting started on cozy application development, you should follow this [tutorial](https://docs.cozy.io/en/dev/app/). [The reference documentation](https://docs.cozy.io/en/cozy-client-js/README/) is the place to see what you can do with this lib, and how to do it!
 
-
-Contribute
-----------
+## Contribute
 
 If you want to work on cozy-client-js itself and submit code modifications, feel free to open pull-requests! See the [contributing guide][contribute] for more information about this repository structure, testing, linting and how to properly open pull-requests.
 
-
-Community
----------
-
-### Maintainer
-
-The lead maintainer for cozy-client-js is @aenario, send him/her a :beers: to say hello!
+## Community
 
 ### Get in touch
 
@@ -47,16 +33,13 @@ You can reach the Cozy Community by:
 - Posting issues on the [Github repos][github]
 - Say Hi! on [Twitter][twitter]
 
+## Licence
 
-Licence
--------
+cozy-client-js is developed by Cozy Cloud and distributed under the [MIT][mit].
 
-cozy-client-js is developed by Cozy Cloud and distributed under the [MIT][MIT].
-
-
-[cozy]: https://cozy.io "Cozy Cloud"
+[cozy]: https://cozy.io 'Cozy Cloud'
 [doctypes]: https://cozy.github.io/cozy-doctypes/
-[MIT]: https://opensource.org/licenses/MIT
+[mit]: https://opensource.org/licenses/MIT
 [contribute]: CONTRIBUTING.md
 [freenode]: http://webchat.freenode.net/?randomnick=1&channels=%23cozycloud&uio=d4
 [forum]: https://forum.cozy.io/

--- a/docs/deprecated.md
+++ b/docs/deprecated.md
@@ -1,3 +1,3 @@
-⚠️ cozy-client-js is a depreacted librairy. We recommend you to use our new client : [Cozy Client](https://docs.cozy.io/en/cozy-client/getting-started/)
+⚠️ cozy-client-js is a deprecated library. We recommend to use our new client : [Cozy Client](https://docs.cozy.io/en/cozy-client/getting-started/)
 
 If you really need to see the documention of cozy-client-js, see it on [github](https://github.com/cozy/cozy-client-js/blob/master/docs/README.md)

--- a/docs/deprecated.md
+++ b/docs/deprecated.md
@@ -1,0 +1,3 @@
+⚠️ cozy-client-js is a depreacted librairy. We recommend you to use our new client : [Cozy Client](https://docs.cozy.io/en/cozy-client/getting-started/)
+
+If you really need to see the documention of cozy-client-js, see it on [github](https://github.com/cozy/cozy-client-js/blob/master/docs/README.md)

--- a/docs/deprecated.md
+++ b/docs/deprecated.md
@@ -1,3 +1,3 @@
 ⚠️ cozy-client-js is a deprecated library. We recommend to use our new client : [Cozy Client](https://docs.cozy.io/en/cozy-client/getting-started/)
 
-If you really need to see the documention of cozy-client-js, see it on [github](https://github.com/cozy/cozy-client-js/blob/master/docs/README.md)
+If you really need to see the documentation of cozy-client-js, see it on [github](https://github.com/cozy/cozy-client-js/blob/master/docs/README.md)

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -1,12 +1,1 @@
-- "README": ./README.md   
-- "Introduction": ./intro.md   
-- "Transition from cozy-browser-sdk": ./browser-sdk-transition.md  
-- "How to support offline": ./offline.md   
-- "OAuth guide": ./oauth.md    
-- "Authentication API": ./auth-api.md  
-- "Data System API": ./data-api.md 
-- "Files API": ./files-api.md  
-- "Jobs API": ./jobs-api.md    
-- "Intents API": ./intents-api.md  
-- "Settings API": ./settings-api.md    
-- "Sharing API": ./sharing-api.md
+- 'Deprecated': ./deprecated.md


### PR DESCRIPTION
You want that cozy-client-js not being indexed
in our official documentation since is a bit
confusing for our users.

If really needed, the user can still access
to the doc on github