### PR TITLE
feat: add method to fetch capabilities

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -133,6 +133,7 @@ const settingsProto = {
   changePassphrase: settings.changePassphrase,
   getInstance: settings.getInstance,
   updateInstance: settings.updateInstance,
+  getCapabilities: settings.getCapabilities,
   getClients: settings.getClients,
   deleteClientById: settings.deleteClientById,
   updateLastSync: settings.updateLastSync

--- a/src/settings.js
+++ b/src/settings.js
@@ -19,6 +19,10 @@ export function updateInstance(cozy, instance) {
   return cozyFetchJSON(cozy, 'PUT', `/settings/instance`, instance)
 }
 
+export function getCapabilities(cozy) {
+  return cozyFetchJSON(cozy, 'GET', `/settings/capabilities`)
+}
+
 export function getClients(cozy) {
   return cozyFetchJSON(cozy, 'GET', `/settings/clients`)
 }


### PR DESCRIPTION
The Cozy's capabilities route is separated from the rest of the
instance's settings so we need a method to fetch this resource.
It's necessary to know which Swift layout is used by the Cozy and if
it's using flat or nested subdomains.