### PR TITLE
feat: Send Executable with file update

### DIFF
--- a/src/files.js
+++ b/src/files.js
@@ -87,6 +87,10 @@ async function doUpload(cozy, data, method, path, options) {
     updatedAt = lastModifiedDate
   }
 
+  if (!executable) {
+    executable = false
+  }
+
   let finalpath = path
   if (metadata) {
     const metadataId = await sendMetadata(cozy, metadata)
@@ -117,6 +121,9 @@ async function doUpload(cozy, data, method, path, options) {
       'UpdatedAt',
       dateString(updatedAt)
     )
+  }
+  if (executable) {
+    finalpath = addQuerystringParam(finalpath, 'Executable', executable)
   }
 
   const headers = {
@@ -151,7 +158,7 @@ async function sendMetadata(cozy, metadata) {
 }
 
 export function create(cozy, data, options) {
-  let { name, dirID, executable, noSanitize } = options || {}
+  let { name, dirID, noSanitize } = options || {}
 
   // handle case where data is a file and contains the name
   if (!name && typeof data.name === 'string') {
@@ -166,14 +173,8 @@ export function create(cozy, data, options) {
     throw new Error('missing name argument')
   }
 
-  if (executable === undefined) {
-    executable = false
-  }
-
   const path = `/files/${encodeURIComponent(dirID || '')}`
-  const query = `?Name=${encodeURIComponent(
-    name
-  )}&Type=file&Executable=${executable}`
+  const query = `?Name=${encodeURIComponent(name)}&Type=file`
   return doUpload(cozy, data, 'POST', `${path}${query}`, options)
 }
 


### PR DESCRIPTION
We can pass the `Executable` query-string parameter when uploading a
new file but `cozy-client-js` does not send it when uploading a new
version although `cozy-stack` accepts it.

Clients like `cozy-desktop` should be able to pass this parameter
along to keep it in sync with their local metadata.