### PR TITLE
fix: Allow 401 errors for expired tokens

### DIFF
--- a/src/fetch.js
+++ b/src/fetch.js
@@ -184,7 +184,7 @@ FetchError.isInvalidToken = function(err) {
   // XXX We can't use err instanceof FetchError because of the caveats of babel
   return (
     err.name === 'FetchError' &&
-    err.status === 400 &&
+    (err.status === 400 || err.status === 401) &&
     err.reason &&
     (err.reason.error === 'Invalid JWT token' ||
       err.reason.error === 'Expired token')

--- a/src/offline.js
+++ b/src/offline.js
@@ -181,7 +181,7 @@ export function replicateFromCozy(cozy, doctype, options = {}) {
               options.onComplete && options.onComplete(info)
             })
             .on('error', err => {
-              if (err.error === 'code=400, message=Expired token') {
+              if (/Expired token/.test(err.error)) {
                 cozy.authorize().then(({ client, token }) => {
                   refreshToken(cozy, client, token)
                     .then(newToken => cozy.saveCredentials(client, newToken))


### PR DESCRIPTION
The stack will change the http code used for expired tokens from 400 to
401. This change will allow cozy-client-js to try refreshing the token
in such cases.

See https://github.com/cozy/cozy-stack/pull/3173