### PR TITLE
ci: Bind server to IPv4 address only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ before_script:
   - git clone https://github.com/cozy/cozy-stack.git
   - pushd cozy-stack && make && popd
   - curl -X PUT http://127.0.0.1:5984/{_users,_replicator,_global_changes}
-  - $GOPATH/bin/cozy-stack serve &
+  - $GOPATH/bin/cozy-stack serve --host 127.0.0.1 --admin-host 127.0.0.1 &
   - sleep 1
   - $GOPATH/bin/cozy-stack instances add --passphrase "$COZY_V3_PASSPHRASE" "$COZY_V3_DOMAIN"
   - $GOPATH/bin/cozy-stack apps install --domain "$COZY_V3_DOMAIN" mini "file://$(pwd)/test/webapp"


### PR DESCRIPTION
Travis does not allow binding IPv6 addresses on their Full VM images
which is the only option for `amd64` architectures.

Since we don't really care about having an IPv6 bound server for our
builds, we can force the hosts to an IPv4 address.